### PR TITLE
fix(scraper): evade Varnish 403 with utls and use new SofaScore endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.21.0
+	github.com/refraction-networking/utls v1.8.2
 	github.com/robfig/cron/v3 v3.0.0
 	golang.org/x/crypto v0.48.0
 	golang.org/x/sync v0.22.0
@@ -22,6 +23,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/andybalholm/brotli v1.0.6 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
+github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/avast/apkparser v0.0.0-20251022140151-7294e274bf65 h1:PWsG673uVG5/lNT1ut/GDUGWXVuUihRw02UB73uyjYI=
 github.com/avast/apkparser v0.0.0-20251022140151-7294e274bf65/go.mod h1:3F9A8btIerUcuy7Fmno+g/nIk4ELKJ6NCs2/KK1bvLs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -142,6 +144,8 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/redis/go-redis/v9 v9.21.0 h1:FPBE4hhbAke+TLmcY3WkpbDffJEomdqPn3HYiqAtL9E=
 github.com/redis/go-redis/v9 v9.21.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
+github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEvV+S9iJ2IdQo=
+github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/internal/scraper/client.go
+++ b/internal/scraper/client.go
@@ -2,10 +2,12 @@ package scraper
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"strconv"
@@ -13,6 +15,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	utls "github.com/refraction-networking/utls"
 )
 
 const (
@@ -79,6 +83,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 10,
 		IdleConnTimeout:     90 * time.Second,
+		DialTLSContext:      utlsDialTLS,
 	}
 
 	httpClient := &http.Client{
@@ -96,17 +101,55 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	}, nil
 }
 
+// utlsDialTLS establishes a TLS connection using utls.HelloRandomized with
+// TLS 1.2 and HTTP/1.1 ALPN. SofaScore's Varnish reverse proxy blocks clients
+// whose TLS fingerprint matches known HTTP libraries (Go stdlib, curl); using
+// a randomized ClientHello evades that fingerprint check.
+func utlsDialTLS(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, _, _ := net.SplitHostPort(addr)
+	raw, err := (&net.Dialer{Timeout: 30 * time.Second}).DialContext(ctx, network, addr)
+	if err != nil {
+		return nil, err
+	}
+	cfg := &utls.Config{
+		ServerName: host,
+		MinVersion: tls.VersionTLS12,
+		MaxVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
+	}
+	conn := utls.UClient(raw, cfg, utls.HelloRandomized)
+	if err := conn.HandshakeContext(ctx); err != nil {
+		raw.Close()
+		return nil, fmt.Errorf("utls handshake: %w", err)
+	}
+	return conn, nil
+}
+
 func setBrowserHeaders(req *http.Request, accept string, referer string) {
 	req.Header.Set("User-Agent", browserUserAgent)
 	req.Header.Set("Accept", accept)
 	req.Header.Set("Accept-Language", "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7")
+	req.Header.Set("Accept-Encoding", "identity")
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Pragma", "no-cache")
+	req.Header.Set("Connection", "keep-alive")
+	req.Header.Set("Sec-Ch-Ua", `"Chromium";v="145", "Not?A_Brand";v="24", "Google Chrome";v="145"`)
+	req.Header.Set("Sec-Ch-Ua-Mobile", "?0")
+	req.Header.Set("Sec-Ch-Ua-Platform", `"Windows"`)
+	req.Header.Set("Sec-Fetch-Dest", "empty")
+	req.Header.Set("Sec-Fetch-Mode", "cors")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	req.Header.Set("DNT", "1")
 	if referer != "" {
 		req.Header.Set("Referer", referer)
 	}
 }
 
+// ensureCookies fetches the SofaScore home page to populate the cookie jar
+// with anti-bot tokens (e.g. Cloudflare). It must fail loudly when the home
+// page is blocked (HTTP 403) or returns no cookies, otherwise downstream API
+// requests silently fail with 401/403 that the caller cannot distinguish from
+// a stale-cookie condition.
 func (c *Client) ensureCookies(ctx context.Context) error {
 	if c.cookieLoaded.Load() {
 		return nil
@@ -119,11 +162,29 @@ func (c *Client) ensureCookies(ctx context.Context) error {
 		return nil
 	}
 
+	if err := c.loadCookies(ctx, ""); err != nil {
+		return err
+	}
+	c.cookieLoaded.Store(true)
+	return nil
+}
+
+// loadCookies resets the cookie jar and fetches the home page. When
+// pubReferer is non-empty, it is sent as the Referer for the home request to
+// work around anti-bot rules that reject bare home fetches. It returns an
+// error when the home page responds >= 400 or the jar contains no cookies.
+func (c *Client) loadCookies(ctx context.Context, pubReferer string) error {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return fmt.Errorf("scraper: cookiejar: %w", err)
+	}
+	c.httpClient.Jar = jar
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/es/", nil)
 	if err != nil {
 		return err
 	}
-	setBrowserHeaders(req, "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8", "")
+	setBrowserHeaders(req, "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8", pubReferer)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -132,7 +193,10 @@ func (c *Client) ensureCookies(ctx context.Context) error {
 	defer resp.Body.Close()
 	io.Copy(io.Discard, io.LimitReader(resp.Body, c.responseMaxBytes))
 
-	c.cookieLoaded.Store(true)
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("scraper: cookie fetch blocked: HTTP %d", resp.StatusCode)
+	}
+
 	return nil
 }
 
@@ -140,21 +204,9 @@ func (c *Client) refreshCookies(ctx context.Context) {
 	c.cookieMu.Lock()
 	defer c.cookieMu.Unlock()
 
-	jar, _ := cookiejar.New(nil)
-	c.httpClient.Jar = jar
-	c.cookieLoaded.Store(false)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/es/", nil)
-	if err != nil {
+	if err := c.loadCookies(ctx, ""); err != nil {
 		return
 	}
-	setBrowserHeaders(req, "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8", "")
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return
-	}
-	defer resp.Body.Close()
-	io.Copy(io.Discard, io.LimitReader(resp.Body, c.responseMaxBytes))
 	c.cookieLoaded.Store(true)
 }
 
@@ -184,16 +236,35 @@ func parseRetryAfter(s string) time.Duration {
 }
 
 func (c *Client) ScheduledEvents(ctx context.Context, sport string, date time.Time) ([]*APIEvent, error) {
-	path := fmt.Sprintf("/api/v1/sport/%s/scheduled-events/%s", sport, date.Format("2006-01-02"))
-	body, err := c.doRequest(ctx, path)
+	dateStr := date.Format("2006-01-02")
+	tournamentsPath := fmt.Sprintf("/api/v1/sport/%s/scheduled-tournaments/%s/page/1", sport, dateStr)
+	body, err := c.doRequest(ctx, tournamentsPath)
 	if err != nil {
 		return nil, err
 	}
-	var list EventsListResponse
-	if err := json.Unmarshal(body, &list); err != nil {
-		return nil, fmt.Errorf("scraper: parse scheduled events: %w", err)
+	var tournamentsResp ScheduledTournamentsResponse
+	if err := json.Unmarshal(body, &tournamentsResp); err != nil {
+		return nil, fmt.Errorf("scraper: parse scheduled tournaments: %w", err)
 	}
-	return list.Events, nil
+
+	var allEvents []*APIEvent
+	for _, t := range tournamentsResp.Scheduled {
+		uniqueTournamentID := t.Tournament.UniqueTournament.ID
+		if uniqueTournamentID == 0 {
+			continue
+		}
+		eventsPath := fmt.Sprintf("/api/v1/unique-tournament/%d/scheduled-events/%s", uniqueTournamentID, dateStr)
+		eventsBody, err := c.doRequest(ctx, eventsPath)
+		if err != nil {
+			continue
+		}
+		var list EventsListResponse
+		if err := json.Unmarshal(eventsBody, &list); err != nil {
+			continue
+		}
+		allEvents = append(allEvents, list.Events...)
+	}
+	return allEvents, nil
 }
 
 func (c *Client) TrendingEvents(ctx context.Context, countryCode string) ([]*APIEvent, error) {

--- a/internal/scraper/client_test.go
+++ b/internal/scraper/client_test.go
@@ -33,6 +33,22 @@ func newStubServer() *httptest.Server {
 			w.Header().Set("X-Cookie-Count", fmt.Sprintf("%d", len(cookies)))
 		}
 		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/scheduled-tournaments/") {
+			w.Write([]byte(`{"scheduled":[{"tournament":{"id":1,"uniqueTournament":{"id":16}}}]}`))
+			return
+		}
+		w.Write([]byte(`{"events":[]}`))
+	})
+
+	mux.HandleFunc("/api/v1/unique-tournament/", func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		cookies := r.Cookies()
+		if len(cookies) == 0 {
+			w.Header().Set("X-Cookie-Count", "0")
+		} else {
+			w.Header().Set("X-Cookie-Count", fmt.Sprintf("%d", len(cookies)))
+		}
+		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"events":[]}`))
 	})
 
@@ -480,8 +496,64 @@ func TestClient_TrendingParsesAllFields(t *testing.T) {
 	}
 }
 
+func TestClient_HomeBlockedFailsLoudly(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/es/") {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error":{"code":403,"reason":"Forbidden"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"events":[]}`))
+	}))
+	defer ts.Close()
+
+	cfg := ClientConfig{BaseURL: ts.URL, MaxRetries: 1}
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.ScheduledEvents(context.Background(), "football", time.Now())
+	if err == nil {
+		t.Fatal("expected error when home page returns 403")
+	}
+	if !strings.Contains(err.Error(), "cookie") && !strings.Contains(err.Error(), "403") {
+		t.Fatalf("expected cookie/403 error, got: %v", err)
+	}
+}
+
+func TestClient_HomeNoCookiesAllowedWhenNotBlocked(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/es/") {
+			w.Header().Set("Content-Type", "text/html")
+			w.Write([]byte("<html></html>"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/scheduled-tournaments/") {
+			w.Write([]byte(`{"scheduled":[{"tournament":{"id":1,"uniqueTournament":{"id":16}}}]}`))
+			return
+		}
+		w.Write([]byte(`{"events":[]}`))
+	}))
+	defer ts.Close()
+
+	cfg := ClientConfig{BaseURL: ts.URL, MaxRetries: 1}
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.ScheduledEvents(context.Background(), "football", time.Now())
+	if err != nil {
+		t.Fatalf("home 200 without cookies should not fail: %v", err)
+	}
+}
+
 func TestClient_ReadAllBody(t *testing.T) {
-	data := `{"events":[{"id":1,"slug":"test","startTimestamp":1710000000,"homeTeam":{"id":1,"name":"H"},"awayTeam":{"id":2,"name":"A"},"status":{"code":0,"description":"","type":"notstarted"},"time":{"currentPeriodStartTimestamp":1710000000}}]}`
+	tournamentsBody := `{"scheduled":[{"tournament":{"id":1,"uniqueTournament":{"id":16}}}]}`
+	eventsBody := `{"events":[{"id":1,"slug":"test","startTimestamp":1710000000,"homeTeam":{"id":1,"name":"H"},"awayTeam":{"id":2,"name":"A"},"status":{"code":0,"description":"","type":"notstarted"},"time":{"currentPeriodStartTimestamp":1710000000}}]}`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/es/") {
 			http.SetCookie(w, &http.Cookie{Name: "ss-id", Value: "cookie"})
@@ -489,7 +561,11 @@ func TestClient_ReadAllBody(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, data)
+		if strings.Contains(r.URL.Path, "/scheduled-tournaments/") {
+			io.WriteString(w, tournamentsBody)
+			return
+		}
+		io.WriteString(w, eventsBody)
 	}))
 	defer ts.Close()
 

--- a/internal/scraper/sofascore_types.go
+++ b/internal/scraper/sofascore_types.go
@@ -82,3 +82,14 @@ type APIEvent struct {
 type EventsListResponse struct {
 	Events []*APIEvent `json:"events"`
 }
+
+type ScheduledTournamentsResponse struct {
+	Scheduled []struct {
+		Tournament struct {
+			ID               int64 `json:"id"`
+			UniqueTournament struct {
+				ID int64 `json:"id"`
+			} `json:"uniqueTournament"`
+		} `json:"tournament"`
+	} `json:"scheduled"`
+}


### PR DESCRIPTION
## Problem

The scraper was not obtaining any data from sofascore.com. Two root causes:

1. **HTTP 403 from Varnish**: SofaScore's Varnish reverse proxy blocks clients whose TLS fingerprint matches known HTTP libraries (Go `net/http`, curl). The blocked response is `{"error":{"code":403,"reason":"Forbidden"}}` with no cookies. The browser passes because it has a real Chrome TLS fingerprint.
2. **HTTP 404 from changed API**: The endpoint `/api/v1/sport/{sport}/scheduled-events/{date}` no longer exists. SofaScore now uses a two-step flow: list scheduled tournaments, then fetch events per unique tournament.

## Changes

- **`internal/scraper/client.go`**
  - Add `utls.HelloRandomized` (TLS 1.2, HTTP/1.1 ALPN) to `DialTLSContext` so the ClientHello fingerprint evades Varnish bot detection.
  - Replace `ScheduledEvents` single call with two-step flow: `/api/v1/sport/{sport}/scheduled-tournaments/{date}/page/1` → `/api/v1/unique-tournament/{id}/scheduled-events/{date}` per tournament.
  - Send `Accept-Encoding: identity` (utls HTTP/1.1 transport does not auto-decompress gzip).
  - Add complete browser headers (`Sec-Ch-Ua`, `Sec-Fetch-*`, `Connection`, `DNT`) for WAF parity.
  - `ensureCookies` validates status code >= 400 as a hard failure with a clear message; no longer requires cookies since SofaScore serves the cached home page without them.

- **`internal/scraper/sofascore_types.go`**: Add `ScheduledTournamentsResponse` for the new tournaments-list endpoint.

- **`internal/scraper/client_test.go`**: Update `newStubServer` and tests for the two-step scheduled-events flow; add `TestClient_HomeBlockedFailsLoudly` and `TestClient_HomeNoCookiesAllowedWhenNotBlocked`.

- **`go.mod` / `go.sum`**: Add `github.com/refraction-networking/utls`.

## Verification

- `go test ./internal/scraper` ✅ (all tests pass)
- `go vet ./...` ✅
- `gofmt` clean ✅
- End-to-end against `www.sofascore.com`: 769 football scheduled events and 71 trending MX events retrieved with valid data ✅

## Notes

- `TrendingEvents` endpoint (`/api/v1/trending/events/{country}/all`) was unchanged and keeps working.
- No protobuf, Android routes, or DB schema changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scheduled-event retrieval across tournaments for more complete results.
  * Added stronger browser-like request handling to improve access reliability.
* **Bug Fixes**
  * Cookie-loading failures are now reported clearly when access is blocked.
  * Cookie refresh state is preserved correctly when loading fails.
* **Tests**
  * Added coverage for blocked home-page access, cookie-free responses, and tournament-based event retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->