### PR TITLE
fix(ci): make sudo optional for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,7 +102,6 @@ jobs:
             echo "The production runner must use Ubuntu" >&2
             exit 1
           }
-          sudo -n true
           missing=()
           for package in ca-certificates curl git python3; do
             if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q 'install ok installed'; then
@@ -110,6 +109,10 @@ jobs:
             fi
           done
           if ((${#missing[@]})); then
+            if ! sudo -n true; then
+              echo "Missing packages: ${missing[*]}. Install them or enable passwordless sudo for the runner." >&2
+              exit 1
+            fi
             sudo -n apt-get update
             sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing[@]}"
           fi
@@ -138,7 +141,6 @@ jobs:
             echo "The production runner must run as iptv" >&2
             exit 1
           }
-          sudo -n true
           for command in curl git go node npm python3 systemctl; do
             command -v "$command" >/dev/null || {
               echo "Missing required command: $command" >&2

--- a/deployments/native/workflow_test.sh
+++ b/deployments/native/workflow_test.sh
@@ -70,6 +70,11 @@ require 'ref: ${{ needs.verify.outputs.sha }}'
 require 'runs-on: [self-hosted, iptv]'
 require 'cancel-in-progress: false'
 require 'for package in ca-certificates curl git python3; do'
+require 'if ! sudo -n true; then'
+[[ $(grep -Fc 'sudo -n true' "$workflow") -eq 1 ]] || {
+  echo 'passwordless sudo must only be required when packages are missing' >&2
+  exit 1
+}
 require 'for command in curl git go node npm python3 systemctl; do'
 require 'EXPECTED_SHA: ${{ needs.verify.outputs.sha }}'
 require '[[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]'


### PR DESCRIPTION
## Summary
- remove unconditional passwordless-sudo checks from the production deployment
- use sudo only when required base packages are actually missing
- emit a clear diagnostic when package installation is needed but passwordless sudo is unavailable
- add a workflow contract regression ensuring normal deployment preflight does not require sudo

## Root cause
The self-hosted `iptv` runner already has the required dependencies, but the workflow executed `sudo -n true` unconditionally. Since that account requires a sudo password, deployment stopped before checkout or build.

## Validation
- reproduced the contract failure before the workflow change
- native workflow contract passes against the committed files
- `actionlint` passes for all workflows, allowing only the repository-specific `iptv` runner label
- `git diff --check origin/main...HEAD` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production deployment checks for missing system packages.
  * Added clearer error messages when passwordless administrative access is required.
  * Removed unnecessary administrative access checks during prerequisite verification.

* **Tests**
  * Updated deployment validation to confirm that passwordless administrative access is checked before package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->