### PR TITLE
fix(ci): print dependency installation commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,12 +109,11 @@ jobs:
             fi
           done
           if ((${#missing[@]})); then
-            if ! sudo -n true; then
-              echo "Missing packages: ${missing[*]}. Install them or enable passwordless sudo for the runner." >&2
-              exit 1
-            fi
-            sudo -n apt-get update
-            sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing[@]}"
+            echo "Missing packages: ${missing[*]}" >&2
+            echo "Run these commands on the production server:" >&2
+            echo "  sudo apt-get update" >&2
+            echo "  sudo apt-get install -y ${missing[*]}" >&2
+            exit 1
           fi
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/deployments/native/workflow_test.sh
+++ b/deployments/native/workflow_test.sh
@@ -70,11 +70,13 @@ require 'ref: ${{ needs.verify.outputs.sha }}'
 require 'runs-on: [self-hosted, iptv]'
 require 'cancel-in-progress: false'
 require 'for package in ca-certificates curl git python3; do'
-require 'if ! sudo -n true; then'
-[[ $(grep -Fc 'sudo -n true' "$workflow") -eq 1 ]] || {
-  echo 'passwordless sudo must only be required when packages are missing' >&2
+require 'Run these commands on the production server:'
+require 'sudo apt-get update'
+require 'sudo apt-get install -y ${missing[*]}'
+if grep -Fq 'sudo -n' "$workflow"; then
+  echo 'the deployment workflow must not attempt non-interactive sudo' >&2
   exit 1
-}
+fi
 require 'for command in curl git go node npm python3 systemctl; do'
 require 'EXPECTED_SHA: ${{ needs.verify.outputs.sha }}'
 require '[[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]'


### PR DESCRIPTION
## Summary
- stop attempting non-interactive sudo from the production deployment workflow
- when packages are missing, print copy-ready commands for an operator to run over SSH
- keep deployment blocked until the server dependencies are installed
- enforce the behavior through the native workflow contract test

## Example failure output
```text
Missing packages: git
Run these commands on the production server:
  sudo apt-get update
  sudo apt-get install -y git
```

## Validation
- regression failed before the workflow change
- committed workflow contract passes
- `actionlint` passes for all workflows, allowing only the repository-specific `iptv` runner label
- `git diff --check origin/main...HEAD` passes