### PR TITLE
fix(deploy): validate runtime environment before publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,7 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Verify production prerequisites
+        id: runtime
         shell: bash
         run: |
           [[ "$(uname -s)" == "Linux" ]]
@@ -154,6 +155,24 @@ jobs:
               exit 1
             }
           done
+          environment_file=/etc/iptv/iptv.env
+          [[ -r "$environment_file" ]] || {
+            echo "Service environment file is not readable: $environment_file" >&2
+            exit 1
+          }
+          if ! grep -Eq '^JWT_SECRET=.+$' "$environment_file"; then
+            echo "JWT_SECRET is missing from $environment_file" >&2
+            echo "Run this command on the production server:" >&2
+            echo '  python3 -c '\''import secrets; print("JWT_SECRET=" + secrets.token_hex(32))'\'' | sudo tee -a /etc/iptv/iptv.env >/dev/null' >&2
+            exit 1
+          fi
+          api_addr=$(grep -E '^API_ADDR=' "$environment_file" | tail -n 1 | cut -d= -f2-)
+          health_port=${api_addr##*:}
+          [[ "$health_port" =~ ^[0-9]+$ ]] || {
+            echo "API_ADDR must end in a numeric port in $environment_file; got: $api_addr" >&2
+            exit 1
+          }
+          echo "health_url=http://127.0.0.1:${health_port}/health/ready" >> "$GITHUB_OUTPUT"
 
       - name: Build dashboard
         working-directory: web
@@ -169,6 +188,7 @@ jobs:
       - name: Publish and verify
         env:
           EXPECTED_SHA: ${{ needs.verify.outputs.sha }}
+          HEALTH_URL: ${{ steps.runtime.outputs.health_url }}
         run: |
           [[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]] || {
             echo "Checked out revision does not match selected SHA $EXPECTED_SHA" >&2

--- a/deployments/native/workflow_test.sh
+++ b/deployments/native/workflow_test.sh
@@ -96,6 +96,14 @@ fi
   exit 1
 }
 require 'systemctl --user show iptv.service'
+require 'id: runtime'
+require 'environment_file=/etc/iptv/iptv.env'
+require "grep -Eq '^JWT_SECRET=.+$' \"\$environment_file\""
+require 'secrets.token_hex(32)'
+require 'sudo tee -a /etc/iptv/iptv.env'
+require 'health_port=${api_addr##*:}'
+require 'echo "health_url=http://127.0.0.1:${health_port}/health/ready" >> "$GITHUB_OUTPUT"'
+require 'HEALTH_URL: ${{ steps.runtime.outputs.health_url }}'
 require 'uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4'
 require 'uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5'
 require 'uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4'

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -301,7 +301,7 @@ Verification and diagnostics:
 
 ```bash
 systemctl --user status iptv.service --no-pager
-curl --fail http://127.0.0.1:8080/health/ready
+curl --fail http://127.0.0.1:9065/health/ready
 journalctl --user -u iptv.service -n 100 --no-pager
 ```
 
@@ -316,7 +316,7 @@ docker compose -f deployments/docker/compose.dev.yml up --build
 # Native production service
 systemctl --user restart iptv.service
 systemctl --user status iptv.service --no-pager
-curl --fail http://127.0.0.1:8080/health/ready
+curl --fail http://127.0.0.1:9065/health/ready
 
 # Run tests (requires compose.test.yml services up)
 docker compose -f deployments/docker/compose.test.yml up -d mariadb redis

--- a/docs/superpowers/specs/2026-07-19-native-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-07-19-native-production-deployment-design.md
@@ -97,7 +97,7 @@ The script must:
 4. atomically replace `/opt/iptv/iptv` and `/opt/iptv/web/dist` without touching the service environment, `apk_storage`, or `image_storage`;
 5. preserve executable mode on the installed binary;
 6. restart with `systemctl --user restart iptv.service`;
-7. require both an active service and a successful readiness response from `http://127.0.0.1:8080/health/ready`.
+7. derive the local readiness URL from `API_ADDR` in `/etc/iptv/iptv.env`, then require both an active service and a successful `/health/ready` response.
 
 The script must clean temporary staging data on exit. The previous successful artifacts remain available for rollback and are replaced on the next deployment.
 


### PR DESCRIPTION
## Root cause
The production binary failed immediately because `/etc/iptv/iptv.env` does not define the now-required `JWT_SECRET`. The deploy health check also assumed port 8080 while production declares `API_ADDR=0.0.0.0:9065`.

## Changes
- validate that `/etc/iptv/iptv.env` is readable and contains a non-empty `JWT_SECRET` before building or replacing production artifacts
- print a copy-ready command that securely generates and appends `JWT_SECRET` when it is missing
- derive the local `/health/ready` URL from the port in `API_ADDR`
- pass the derived URL into the native publisher
- update workflow contract tests and production documentation

## Validation
- reproduced the missing workflow requirements before implementation
- native workflow contract passes
- `actionlint` passes for all workflows, allowing only the repository-specific `iptv` label
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check origin/main...HEAD`

## Required server preparation
Run once before retrying deployment:

```bash
python3 -c 'import secrets; print("JWT_SECRET=" + secrets.token_hex(32))' | sudo tee -a /etc/iptv/iptv.env >/dev/null
```

The next deploy will read port `9065` from the existing `API_ADDR` entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Production deployments now derive the service readiness URL from runtime configuration, improving compatibility across environments.
  - Deployment verification confirms required security configuration and validates the service’s readiness endpoint before publishing.

- **Documentation**
  - Updated the operations runbook and deployment design guidance to reflect configuration-based readiness checks and the current native service endpoint.

- **Tests**
  - Expanded deployment workflow validation to cover runtime outputs, security settings, generated secrets, and health-check signaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->