### PR TITLE
fix(deploy): connect to systemd user bus

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,6 +141,13 @@ jobs:
             echo "The production runner must run as iptv" >&2
             exit 1
           }
+          runtime_dir="/run/user/$(id -u)"
+          [[ -S "$runtime_dir/bus" ]] || {
+            echo "systemd user bus is unavailable: $runtime_dir/bus" >&2
+            exit 1
+          }
+          export XDG_RUNTIME_DIR="$runtime_dir"
+          echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"
           for command in curl git go node npm python3 systemctl; do
             command -v "$command" >/dev/null || {
               echo "Missing required command: $command" >&2

--- a/deployments/native/deploy.sh
+++ b/deployments/native/deploy.sh
@@ -20,6 +20,10 @@ git_bin=${GIT_BIN:-git}
 health_attempts=${HEALTH_ATTEMPTS:-30}
 health_delay=${HEALTH_DELAY_SECONDS:-2}
 
+if [[ -z "${XDG_RUNTIME_DIR:-}" ]]; then
+  export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+fi
+
 state_dir="$deploy_root/.deploy"
 stage_dir="$state_dir/stage"
 previous_dir="$state_dir/previous"

--- a/deployments/native/deploy_test.sh
+++ b/deployments/native/deploy_test.sh
@@ -38,6 +38,9 @@ make_fixture() {
 
   cat > "$bin/systemctl" <<'SYSTEMCTL'
 #!/usr/bin/env bash
+if [[ -n "${SYSTEMCTL_ENV_LOG:-}" ]]; then
+  printf '%s\n' "${XDG_RUNTIME_DIR:-}" >> "$SYSTEMCTL_ENV_LOG"
+fi
 printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
 if [[ ("$*" == "--user restart iptv.service" || "$*" == "--user --no-block restart iptv.service") \
   && -n "${SERVICE_STATE_LOG:-}" ]]; then
@@ -373,16 +376,18 @@ printf '200'
 CURL
   chmod +x "$case_dir/bin/curl"
 
-  DEPLOY_ROOT="$case_dir/root" \
-  SYSTEMCTL_BIN="$case_dir/bin/systemctl" \
-  SYSTEMCTL_LOG="$case_dir/systemctl.log" \
-  DASHBOARD_STATE_LOG="$case_dir/dashboard-state.log" \
-  CURL_BIN="$case_dir/bin/curl" \
-  GIT_BIN="$case_dir/bin/git" \
-  GIT_COUNT_FILE="$case_dir/git.count" \
-  REMOTE_MAIN_SHA="$expected_sha" \
-  HEALTH_ATTEMPTS=1 \
-  HEALTH_DELAY_SECONDS=0 \
+  env -u XDG_RUNTIME_DIR \
+    DEPLOY_ROOT="$case_dir/root" \
+    SYSTEMCTL_BIN="$case_dir/bin/systemctl" \
+    SYSTEMCTL_LOG="$case_dir/systemctl.log" \
+    SYSTEMCTL_ENV_LOG="$case_dir/systemctl-env.log" \
+    DASHBOARD_STATE_LOG="$case_dir/dashboard-state.log" \
+    CURL_BIN="$case_dir/bin/curl" \
+    GIT_BIN="$case_dir/bin/git" \
+    GIT_COUNT_FILE="$case_dir/git.count" \
+    REMOTE_MAIN_SHA="$expected_sha" \
+    HEALTH_ATTEMPTS=1 \
+    HEALTH_DELAY_SECONDS=0 \
     "$deploy_script" "$case_dir/artifacts/iptv" "$case_dir/artifacts/web-dist" "$expected_sha"
 
   assert_content new-binary "$case_dir/root/iptv"
@@ -391,6 +396,8 @@ CURL
   assert_content old-binary "$case_dir/root/.deploy/previous/iptv"
   assert_content old-dashboard "$case_dir/root/.deploy/previous/web-dist/index.html"
   grep -Fq -- '--user restart iptv.service' "$case_dir/systemctl.log" || fail "service was not restarted"
+  grep -Fxq "/run/user/$(id -u)" "$case_dir/systemctl-env.log" \
+    || fail "systemctl did not receive the derived user runtime directory"
   grep -Fxq 'new-dashboard|old-dashboard' "$case_dir/dashboard-state.log" || fail "dashboard was not atomically exchanged before restart"
   [[ -x "$case_dir/root/iptv" ]] || fail "installed binary is not executable"
   [[ ! -e "$case_dir/root/web/.dist.new" ]] || fail "exchanged dashboard was not cleaned up"

--- a/deployments/native/workflow_test.sh
+++ b/deployments/native/workflow_test.sh
@@ -96,6 +96,11 @@ fi
   exit 1
 }
 require 'systemctl --user show iptv.service'
+require 'runtime_dir="/run/user/$(id -u)"'
+require '[[ -S "$runtime_dir/bus" ]]'
+require 'export XDG_RUNTIME_DIR="$runtime_dir"'
+require 'echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"'
+reject '/run/user/1001'
 require 'id: runtime'
 require 'environment_file=/etc/iptv/iptv.env'
 require "grep -Eq '^JWT_SECRET=.+$' \"\$environment_file\""

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -297,12 +297,21 @@ Production layout:
 
 The existing user service is `/home/iptv/.config/systemd/user/iptv.service`. Its environment remains outside the repository. Startup applies forward database migrations; automatic artifact rollback does not run down migrations.
 
+The runner executes inside a TrueNAS system container with systemd as PID 1.
+The `iptv` user manager must remain active with its bus at
+`/run/user/$(id -u iptv)/bus`. GitHub Actions derives and propagates
+`XDG_RUNTIME_DIR` dynamically; the UID must not be hardcoded.
+
 Verification and diagnostics:
 
 ```bash
-systemctl --user status iptv.service --no-pager
+sudo -u iptv env XDG_RUNTIME_DIR="/run/user/$(id -u iptv)" \
+  systemctl --user status iptv.service --no-pager
+sudo -u iptv env XDG_RUNTIME_DIR="/run/user/$(id -u iptv)" \
+  systemctl --user restart iptv.service
+sudo -u iptv env XDG_RUNTIME_DIR="/run/user/$(id -u iptv)" \
+  journalctl --user -u iptv.service -n 100 --no-pager
 curl --fail http://127.0.0.1:9065/health/ready
-journalctl --user -u iptv.service -n 100 --no-pager
 ```
 
 Dashboard publication and rollback atomically exchange same-filesystem directories, so `/opt/iptv/web/dist` remains present throughout each operation. If health verification fails, the deployment script restores the previous binary and dashboard and restarts the service. If a migration prevents application rollback, follow `docs/operations/rollback.md` instead of manually running down migrations.
@@ -314,8 +323,10 @@ Dashboard publication and rollback atomically exchange same-filesystem directori
 docker compose -f deployments/docker/compose.dev.yml up --build
 
 # Native production service
-systemctl --user restart iptv.service
-systemctl --user status iptv.service --no-pager
+sudo -u iptv env XDG_RUNTIME_DIR="/run/user/$(id -u iptv)" \
+  systemctl --user restart iptv.service
+sudo -u iptv env XDG_RUNTIME_DIR="/run/user/$(id -u iptv)" \
+  systemctl --user status iptv.service --no-pager
 curl --fail http://127.0.0.1:9065/health/ready
 
 # Run tests (requires compose.test.yml services up)

--- a/docs/superpowers/specs/2026-07-19-native-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-07-19-native-production-deployment-design.md
@@ -15,9 +15,14 @@ The deployment must not use Docker or a container registry. It must preserve the
 - Image storage: `/opt/iptv/image_storage`
 - Service: `iptv.service`, managed with `systemctl --user`
 - Runner: self-hosted Linux runner with labels `self-hosted` and `iptv`
-- Service account: `iptv`, with passwordless `sudo` on Ubuntu
+- Service account: `iptv`
+- Host: TrueNAS system container running systemd as PID 1
 
 The workflow must not replace the service unit or its environment configuration.
+
+The `iptv` user manager exposes its bus at `/run/user/<uid>/bus`. GitHub Actions
+jobs do not inherit `XDG_RUNTIME_DIR`, so the workflow must derive
+`XDG_RUNTIME_DIR=/run/user/$(id -u)` instead of hardcoding the production UID.
 
 ## Trigger And Revision Selection
 
@@ -50,21 +55,30 @@ No repository checkout or source build occurs inside `/opt/iptv`.
 
 ## Dependency Provisioning And Preflight
 
-The runner is Ubuntu. The workflow uses non-interactive passwordless `sudo` to install missing base packages with `apt-get`, including `ca-certificates`, `curl`, and `git`.
+The runner is Ubuntu. The workflow reports commands for an operator to install
+missing base packages with `apt-get`; the deployment itself does not require
+non-interactive sudo access.
 
 Exact build toolchains are provisioned automatically with maintained GitHub Actions:
 
 - Go from `go.mod` (`1.25.x`)
 - Node.js 22 with npm cache keyed by `web/package-lock.json`
 
-Before modifying production, preflight checks must verify:
+Before modifying production, preflight checks must:
 
-- the runner is Linux and passwordless `sudo` works;
-- `systemctl --user` can find `iptv.service`;
+- verify the runner is Linux and executes as `iptv`;
+- derive and export `XDG_RUNTIME_DIR` from the effective UID;
+- verify `$XDG_RUNTIME_DIR/bus` is a Unix socket;
+- propagate `XDG_RUNTIME_DIR` through `$GITHUB_ENV` for later workflow steps;
+- verify `systemctl --user` can find `iptv.service`;
 - `/opt/iptv` exists and is writable by the runner account;
 - `/opt/iptv/apk_storage` and `/opt/iptv/image_storage` exist and are writable;
 - the current service configuration is left in place;
 - `curl`, Go, Node.js, and npm are available after provisioning.
+
+`deployments/native/deploy.sh` derives the same runtime-directory default when
+it is invoked outside the workflow. It preserves an explicitly supplied value
+for tests and alternate systemd user-manager layouts.
 
 Database and Redis connectivity are verified through the application's readiness endpoint after restart. The current scraper uses HTTP with uTLS and has no Chromium runtime dependency.
 
@@ -117,7 +131,7 @@ Application startup runs forward database migrations. Artifact rollback must nev
 - Pull request code never executes on the `iptv` runner.
 - No production secrets are copied into the repository or Actions workspace by this workflow.
 - Existing environment values remain owned by `iptv.service`.
-- `sudo` is used only for package provisioning if a base dependency is missing; application publication and service management run as `iptv`.
+- Base dependency installation is an explicit operator action; application publication and service management run as `iptv`.
 - Workflow logs include the deployed commit SHA but no environment values or credentials.
 
 ## Verification
@@ -127,6 +141,7 @@ Implementation verification must include:
 - YAML parsing and inspection of workflow triggers, permissions, runner labels, concurrency, and SHA selection;
 - `bash -n deployments/native/deploy.sh`;
 - script tests with temporary deployment roots and fake `systemctl`/health commands covering successful publication and failed-health rollback;
+- workflow contract checks for dynamic user runtime-directory derivation, user-bus socket validation, `$GITHUB_ENV` propagation, and absence of a hardcoded UID;
 - `npm ci && npm run build`;
 - `CGO_ENABLED=0 go build ./cmd/server`;
 - existing Go tests and vet checks;


### PR DESCRIPTION
## Summary
- derive and validate the systemd user runtime directory on the TrueNAS runner
- propagate `XDG_RUNTIME_DIR` to publish, rollback, and diagnostic steps
- cover direct deployment defaults and document container operations

## Testing
- `bash deployments/native/workflow_test.sh`
- `wsl -d Ubuntu -- bash deployments/native/deploy_test.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -ignore 'label "iptv" is unknown' .github/workflows/deploy.yml`\n- `go test ./... -count=1`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production deployment reliability by automatically configuring the user runtime environment.
  * Added validation to prevent deployments from proceeding when required system services are unavailable.
  * Ensured deployment commands consistently target the correct user service session.

* **Documentation**
  * Updated production deployment and operational guidance for runtime setup, service management, health checks, and troubleshooting.
  * Clarified environment requirements and dynamic configuration for different deployment hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->