### PR TITLE
fix(database): recover dirty APK semver migration

### DIFF
--- a/docs/operations/rollback.md
+++ b/docs/operations/rollback.md
@@ -108,6 +108,29 @@ docker compose -f deployments/docker/compose.multi.yml exec mariadb \
 
 ---
 
+## Automatic Recovery: Dirty Migration 5
+
+Migration 5 can be left dirty when production's `package_name` column is wider
+than the baseline and `idx_apk_latest` exceeds InnoDB's key limit. The corrected
+binary automatically repairs only `version=5, dirty=true` when all of these
+preconditions hold:
+
+1. `version_major`, `version_minor`, and `version_patch` all exist as `BIGINT UNSIGNED NOT NULL DEFAULT 0`.
+2. Every `version` is `MAJOR.MINOR.PATCH` with decimal digits only, and every component is at most 20 digits and no greater than `18446744073709551615`.
+3. `package_name` is an indexable character column with a positive declared length.
+4. `idx_apk_latest` is absent, or it is a visible, ascending, non-unique `BTREE` over `package_name`, `is_active`, `version_major`, `version_minor`, `version_patch`, and `id` in that order. Its effective `package_name` prefix must be `min(package_name declared length, 191)`; a full-column first key is compatible only when the declared length is at most 191.
+
+When these checks pass, recovery recalculates semver values, creates the missing
+prefix index without changing `package_name`, marks version 5 clean, and
+continues later migrations. Recovery never drops or rewrites an incompatible
+existing index or column definition.
+
+No direct database command is required for this known state. Deploy the
+corrected binary and verify `/health/ready`. Any other dirty version or an
+unexpected partial schema still fails closed and requires database inspection.
+
+---
+
 ## Rollback Procedure (Non-Destructive Migrations)
 
 For non-destructive migrations (001, 002, 005, 006, 007), rollback follows the standard `golang-migrate` approach:

--- a/docs/superpowers/specs/2026-07-20-apk-semver-migration-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-20-apk-semver-migration-recovery-design.md
@@ -1,0 +1,117 @@
+# APK Semver Migration Recovery Design
+
+## Problem
+
+Production failed while applying migration `000005_apk_semver_order`:
+
+```text
+Error 1071 (42000): Specified key was too long; max key length is 3072 bytes
+```
+
+The failure occurred while creating `idx_apk_latest` over the complete
+`package_name` column and four numeric fields. Production's `package_name`
+definition is wider than the repository baseline's `VARCHAR(191)`, so its
+`utf8mb4` index contribution can exceed InnoDB's key limit.
+
+MariaDB committed the preceding DDL before the index failed. The production
+database therefore has the three semver columns but is recorded by
+`golang-migrate` as version 5 with `dirty=true`. Changing the migration SQL
+alone cannot recover this database because `golang-migrate` refuses to run any
+further migration while it is dirty.
+
+## Goals
+
+- Make migration 5 safe when `package_name` is wider than 191 characters.
+- Recover only the known, non-destructive partial state of migration 5.
+- Preserve every APK row and the full `package_name` value.
+- Continue applying later migrations after successful repair.
+- Reject unknown dirty states instead of guessing or forcing them clean.
+
+## Non-Goals
+
+- Generic automatic repair for arbitrary dirty migrations.
+- Truncating or narrowing `package_name`.
+- Automatically rolling back schema or application data.
+- Replacing the existing migration framework.
+
+## Migration Change
+
+Migration 5 will create `idx_apk_latest` using a prefix for the character
+column:
+
+```sql
+CREATE INDEX idx_apk_latest ON apk_versions(
+  package_name(191),
+  is_active,
+  version_major,
+  version_minor,
+  version_patch,
+  id
+);
+```
+
+The prefix bounds the `utf8mb4` contribution to 764 bytes while retaining the
+numeric ordering fields. The query still compares the complete
+`package_name`, so prefix collisions can increase rows examined but cannot
+change results.
+
+## Dirty Migration Recovery
+
+`database.Migrate` already serializes migration work with the MariaDB advisory
+lock. After constructing the `golang-migrate` instance and before calling
+`Up`, it will inspect `Version()`.
+
+No action is taken for a clean database. A dirty version other than 5 returns
+the existing migration error. For exactly `version=5, dirty=true`, a focused
+repair function will perform these checks and operations under the same lock:
+
+1. Confirm `apk_versions` contains all three columns: `version_major`,
+   `version_minor`, and `version_patch`.
+2. Confirm every `version` still matches the migration's strict
+   `MAJOR.MINOR.PATCH` expression.
+3. Recalculate all three numeric columns idempotently from `version`.
+4. Inspect `idx_apk_latest`.
+5. If absent, determine the declared character length of `package_name`, choose
+   `min(length, 191)`, and create the same ordered index with that prefix.
+6. If present, accept it only when its ordered columns match the expected
+   index; reject an incompatible index with the same name.
+7. Call `Force(5)` only after all validation and repair operations succeed.
+8. Call `Up` normally so migrations 6 and later run.
+
+If `package_name` is not an indexable character column, any semver column is
+missing, data is non-semver, or the existing index is incompatible, startup
+fails with a specific diagnostic and leaves the database dirty.
+
+## Failure Safety
+
+The repair does not drop columns, indexes, tables, or rows. Recalculating
+semver fields and creating the missing index are idempotent. The dirty flag is
+cleared last, preventing a partially repaired schema from being reported as
+healthy.
+
+The deployment's existing artifact rollback remains unchanged. Because schema
+repair is additive and migration 5 is non-destructive, the previous binary can
+continue running if a later deployment step fails.
+
+## Testing
+
+MariaDB integration tests will use isolated temporary databases and cover:
+
+- A clean schema at version 4 with `package_name VARCHAR(1024)`, proving the
+  corrected migration 5 applies without exceeding the key limit.
+- The observed partial state: semver columns present, index absent, and
+  `schema_migrations` at dirty version 5. `Migrate` must repair it, clear dirty,
+  create the prefix index, and apply all later migrations.
+- A dirty version other than 5, which must remain dirty and return an error.
+- Dirty migration 5 with missing semver columns or an incompatible existing
+  index, which must fail without forcing the version clean.
+
+Existing empty-database, idempotency, repository ordering, and deployment tests
+must continue to pass.
+
+## Operations
+
+No direct database access is required for the known production state. The first
+startup of the corrected binary performs the constrained repair and records a
+non-secret log message before continuing migrations. Operators verify success
+through `/health/ready` and the deployment workflow.

--- a/internal/platform/database/migrations.go
+++ b/internal/platform/database/migrations.go
@@ -146,8 +146,7 @@ func repairDirtyAPKSemverMigration(ctx context.Context, conn *sql.Conn) error {
 		var nonUnique int
 		var ignored string
 		if err := rows.Scan(&column, &subPart, &collation, &indexType, &nonUnique, &ignored); err != nil {
-			rows.Close()
-			return fmt.Errorf("scan idx_apk_latest: %w", err)
+			return errors.Join(fmt.Errorf("scan idx_apk_latest: %w", err), rows.Close())
 		}
 		if !collation.Valid || collation.String != "A" {
 			allAscending = false

--- a/internal/platform/database/migrations.go
+++ b/internal/platform/database/migrations.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 
@@ -13,36 +14,275 @@ import (
 	"github.com/jeriveromartinez/sofascore-scrapper/migrations"
 )
 
-const lockID = "590872375"
+const (
+	lockID                    = "590872375"
+	apkSemverMigrationVersion = 5
+	maxUnsignedBigInt         = "18446744073709551615"
+)
 
-func Migrate(ctx context.Context, db *sql.DB) error {
-	if err := db.PingContext(ctx); err != nil {
-		return fmt.Errorf("database ping: %w", err)
+var apkLatestIndexColumns = []string{
+	"package_name",
+	"is_active",
+	"version_major",
+	"version_minor",
+	"version_patch",
+	"id",
+}
+
+func repairDirtyAPKSemverMigration(ctx context.Context, conn *sql.Conn) error {
+	var columnCount int
+	if err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'apk_versions'
+		  AND COLUMN_NAME IN ('version_major', 'version_minor', 'version_patch')
+	`).Scan(&columnCount); err != nil {
+		return fmt.Errorf("inspect semver columns: %w", err)
+	}
+	if columnCount != 3 {
+		return fmt.Errorf("expected 3 semver columns, found %d", columnCount)
+	}
+	var compatibleColumnCount int
+	if err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'apk_versions'
+		  AND COLUMN_NAME IN ('version_major', 'version_minor', 'version_patch')
+		  AND DATA_TYPE = 'bigint'
+		  AND COLUMN_TYPE LIKE '% unsigned'
+		  AND IS_NULLABLE = 'NO'
+		  AND COLUMN_DEFAULT = '0'
+	`).Scan(&compatibleColumnCount); err != nil {
+		return fmt.Errorf("inspect semver column definitions: %w", err)
+	}
+	if compatibleColumnCount != 3 {
+		return fmt.Errorf("semver columns have incompatible definitions: %d of 3 match BIGINT UNSIGNED NOT NULL DEFAULT 0", compatibleColumnCount)
 	}
 
-	_, err := db.ExecContext(ctx, fmt.Sprintf("SELECT GET_LOCK('%s', 0)", lockID))
+	var invalidCount int
+	if err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM apk_versions
+		WHERE version NOT REGEXP '^[0-9]+\\.[0-9]+\\.[0-9]+$'
+	`).Scan(&invalidCount); err != nil {
+		return fmt.Errorf("validate APK versions: %w", err)
+	}
+	if invalidCount != 0 {
+		return fmt.Errorf("found %d non-semver APK versions", invalidCount)
+	}
+	var overflowCount int
+	if err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM (
+		  SELECT
+		    SUBSTRING_INDEX(version, '.', 1) AS semver_major,
+		    SUBSTRING_INDEX(SUBSTRING_INDEX(version, '.', 2), '.', -1) AS semver_minor,
+		    SUBSTRING_INDEX(version, '.', -1) AS semver_patch
+		  FROM apk_versions
+		) AS semver_parts
+		WHERE CHAR_LENGTH(semver_major) > 20
+		   OR (CHAR_LENGTH(semver_major) = 20 AND BINARY semver_major > BINARY ?)
+		   OR CHAR_LENGTH(semver_minor) > 20
+		   OR (CHAR_LENGTH(semver_minor) = 20 AND BINARY semver_minor > BINARY ?)
+		   OR CHAR_LENGTH(semver_patch) > 20
+		   OR (CHAR_LENGTH(semver_patch) = 20 AND BINARY semver_patch > BINARY ?)
+	`, maxUnsignedBigInt, maxUnsignedBigInt, maxUnsignedBigInt).Scan(&overflowCount); err != nil {
+		return fmt.Errorf("validate APK semver bounds: %w", err)
+	}
+	if overflowCount != 0 {
+		return fmt.Errorf("found %d APK versions where a semver component exceeds unsigned BIGINT maximum %s", overflowCount, maxUnsignedBigInt)
+	}
+
+	if _, err := conn.ExecContext(ctx, `
+		UPDATE apk_versions SET
+		  version_major = CAST(SUBSTRING_INDEX(version, '.', 1) AS UNSIGNED),
+		  version_minor = CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(version, '.', 2), '.', -1) AS UNSIGNED),
+		  version_patch = CAST(SUBSTRING_INDEX(version, '.', -1) AS UNSIGNED)
+	`); err != nil {
+		return fmt.Errorf("recalculate APK semver columns: %w", err)
+	}
+
+	var declaredLength sql.NullInt64
+	if err := conn.QueryRowContext(ctx, `
+		SELECT CHARACTER_MAXIMUM_LENGTH
+		FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'apk_versions'
+		  AND COLUMN_NAME = 'package_name'
+	`).Scan(&declaredLength); err != nil {
+		return fmt.Errorf("inspect package_name length: %w", err)
+	}
+	if !declaredLength.Valid || declaredLength.Int64 < 1 {
+		return fmt.Errorf("package_name is not an indexable character column")
+	}
+	prefixLength := declaredLength.Int64
+	if prefixLength > 191 {
+		prefixLength = 191
+	}
+
+	rows, err := conn.QueryContext(ctx, `
+		SELECT COLUMN_NAME, SUB_PART, COLLATION, INDEX_TYPE, NON_UNIQUE, IGNORED
+		FROM information_schema.STATISTICS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'apk_versions'
+		  AND INDEX_NAME = 'idx_apk_latest'
+		ORDER BY SEQ_IN_INDEX
+	`)
 	if err != nil {
-		return fmt.Errorf("advisory lock: %w", err)
+		return fmt.Errorf("inspect idx_apk_latest: %w", err)
 	}
-	defer func() {
-		if _, err := db.ExecContext(context.Background(), fmt.Sprintf("SELECT RELEASE_LOCK('%s')", lockID)); err != nil {
-			log.Printf("migrations: release lock: %v", err)
+	var actualColumns []string
+	var actualPrefix sql.NullInt64
+	allAscending := true
+	var actualIndexType string
+	var actualNonUnique int
+	var actualIgnored string
+	for rows.Next() {
+		var column string
+		var subPart sql.NullInt64
+		var collation sql.NullString
+		var indexType string
+		var nonUnique int
+		var ignored string
+		if err := rows.Scan(&column, &subPart, &collation, &indexType, &nonUnique, &ignored); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan idx_apk_latest: %w", err)
 		}
-	}()
+		if !collation.Valid || collation.String != "A" {
+			allAscending = false
+		}
+		if len(actualColumns) == 0 {
+			actualPrefix = subPart
+			actualIndexType = indexType
+			actualNonUnique = nonUnique
+			actualIgnored = ignored
+		}
+		actualColumns = append(actualColumns, column)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close idx_apk_latest rows: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate idx_apk_latest: %w", err)
+	}
+
+	if len(actualColumns) != 0 {
+		if len(actualColumns) != len(apkLatestIndexColumns) {
+			return fmt.Errorf("idx_apk_latest has incompatible columns: %v", actualColumns)
+		}
+		for i := range apkLatestIndexColumns {
+			if actualColumns[i] != apkLatestIndexColumns[i] {
+				return fmt.Errorf("idx_apk_latest has incompatible columns: %v", actualColumns)
+			}
+		}
+		if actualPrefix.Valid {
+			if actualPrefix.Int64 != prefixLength {
+				return fmt.Errorf("idx_apk_latest has incompatible package_name prefix: got %d, want %d", actualPrefix.Int64, prefixLength)
+			}
+		} else if declaredLength.Int64 > 191 {
+			return fmt.Errorf("idx_apk_latest has incompatible package_name prefix: got full length %d, want %d", declaredLength.Int64, prefixLength)
+		}
+		if !allAscending {
+			return fmt.Errorf("idx_apk_latest has incompatible direction: all columns must be ascending")
+		}
+		if actualIndexType != "BTREE" {
+			return fmt.Errorf("idx_apk_latest has incompatible index type %q, want BTREE", actualIndexType)
+		}
+		if actualNonUnique != 1 {
+			return fmt.Errorf("idx_apk_latest must be non-unique")
+		}
+		if actualIgnored != "NO" {
+			return fmt.Errorf("idx_apk_latest is ignored")
+		}
+		return nil
+	}
+
+	statement := fmt.Sprintf(`
+		CREATE INDEX idx_apk_latest ON apk_versions(
+		  package_name(%d), is_active, version_major, version_minor, version_patch, id
+		)
+	`, prefixLength)
+	if _, err := conn.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("create idx_apk_latest: %w", err)
+	}
+	return nil
+}
+
+func releaseMigrationLock(conn *sql.Conn) error {
+	var released sql.NullInt64
+	if err := conn.QueryRowContext(context.Background(), "SELECT RELEASE_LOCK(?)", lockID).Scan(&released); err != nil {
+		return fmt.Errorf("release advisory lock: %w", err)
+	}
+	if !released.Valid || released.Int64 != 1 {
+		return fmt.Errorf("release advisory lock returned %v, want 1", released)
+	}
+	return nil
+}
+
+func closeMigrationConnection(conn *sql.Conn) error {
+	if err := conn.Close(); err != nil {
+		return fmt.Errorf("close migration connection: %w", err)
+	}
+	return nil
+}
+
+func Migrate(ctx context.Context, db *sql.DB) (retErr error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("migration connection: %w", err)
+	}
+	if err := conn.PingContext(ctx); err != nil {
+		return errors.Join(fmt.Errorf("database ping: %w", err), closeMigrationConnection(conn))
+	}
+	var acquired sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", lockID).Scan(&acquired); err != nil {
+		return errors.Join(fmt.Errorf("advisory lock: %w", err), closeMigrationConnection(conn))
+	}
+	if !acquired.Valid || acquired.Int64 != 1 {
+		if acquired.Valid && acquired.Int64 == 0 {
+			return errors.Join(fmt.Errorf("advisory lock is already held"), closeMigrationConnection(conn))
+		}
+		return errors.Join(fmt.Errorf("advisory lock returned %v, want 1", acquired), closeMigrationConnection(conn))
+	}
 
 	src, err := iofs.New(migrations.FS(), ".")
 	if err != nil {
-		return fmt.Errorf("migration source: %w", err)
+		return errors.Join(fmt.Errorf("migration source: %w", err), releaseMigrationLock(conn), closeMigrationConnection(conn))
 	}
 
-	driver, err := mysql.WithInstance(db, &mysql.Config{})
+	driver, err := mysql.WithConnection(ctx, conn, &mysql.Config{})
 	if err != nil {
-		return fmt.Errorf("migration driver: %w", err)
+		return errors.Join(fmt.Errorf("migration driver: %w", err), releaseMigrationLock(conn), closeMigrationConnection(conn), src.Close())
 	}
 
 	m, err := migrate.NewWithInstance("iofs", src, "mysql", driver)
 	if err != nil {
-		return fmt.Errorf("migration instance: %w", err)
+		return errors.Join(fmt.Errorf("migration instance: %w", err), releaseMigrationLock(conn), driver.Close(), src.Close())
+	}
+	defer func() {
+		retErr = errors.Join(retErr, releaseMigrationLock(conn))
+		sourceErr, databaseErr := m.Close()
+		if sourceErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("close migration source: %w", sourceErr))
+		}
+		if databaseErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("close migration database: %w", databaseErr))
+		}
+	}()
+
+	version, dirty, versionErr := m.Version()
+	if versionErr != nil && versionErr != migrate.ErrNilVersion {
+		return fmt.Errorf("migration version: %w", versionErr)
+	}
+	if versionErr == nil && version == apkSemverMigrationVersion && dirty {
+		if err := repairDirtyAPKSemverMigration(ctx, conn); err != nil {
+			return fmt.Errorf("repair dirty migration %d: %w", version, err)
+		}
+		if err := m.Force(int(version)); err != nil {
+			return fmt.Errorf("mark repaired migration %d clean: %w", version, err)
+		}
+		log.Printf("migrations: repaired dirty migration %d", version)
 	}
 
 	if err := m.Up(); err != nil && err != migrate.ErrNoChange {

--- a/internal/platform/database/migrations_integration_test.go
+++ b/internal/platform/database/migrations_integration_test.go
@@ -5,19 +5,32 @@ package database
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
-	_ "github.com/golang-migrate/migrate/v4/database/mysql"
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database/mysql"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+
+	"github.com/jeriveromartinez/sofascore-scrapper/migrations"
 )
 
+var isolatedMigrationDBCounter atomic.Uint64
+
 func dbDSN() string {
+	return dbDSNFor(envOr("DB_NAME", "sofascore"))
+}
+
+func dbDSNFor(name string) string {
 	host := envOr("DB_HOST", "localhost")
 	port := envOr("DB_PORT", "3306")
 	user := envOr("DB_USER", "root")
 	pass := os.Getenv("DB_PASSWORD")
-	name := envOr("DB_NAME", "sofascore")
 	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&multiStatements=true", user, pass, host, port, name)
 }
 
@@ -39,6 +52,149 @@ func openTestDB(t *testing.T) *sql.DB {
 		t.Skipf("no database available: %v", err)
 	}
 	return db
+}
+
+func openIsolatedMigrationDB(t *testing.T) *sql.DB {
+	t.Helper()
+	admin, err := sql.Open("mysql", dbDSNFor(""))
+	if err != nil {
+		t.Fatalf("open admin database: %v", err)
+	}
+	if err := admin.Ping(); err != nil {
+		admin.Close()
+		t.Skipf("no database available: %v", err)
+	}
+
+	name := fmt.Sprintf("sofascore_migration_%d_%d", time.Now().UnixNano(), isolatedMigrationDBCounter.Add(1))
+	if _, err := admin.Exec("CREATE DATABASE `" + name + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"); err != nil {
+		admin.Close()
+		t.Fatalf("create isolated database: %v", err)
+	}
+
+	db, err := sql.Open("mysql", dbDSNFor(name))
+	if err != nil {
+		admin.Exec("DROP DATABASE `" + name + "`")
+		admin.Close()
+		t.Fatalf("open isolated database: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		if _, err := admin.Exec("DROP DATABASE `" + name + "`"); err != nil {
+			t.Errorf("drop isolated database: %v", err)
+		}
+		admin.Close()
+	})
+	return db
+}
+
+func migrateTestDBTo(t *testing.T, db *sql.DB, version uint) {
+	t.Helper()
+	var name string
+	if err := db.QueryRow("SELECT DATABASE()").Scan(&name); err != nil {
+		t.Fatalf("current database: %v", err)
+	}
+	migrationDB, err := sql.Open("mysql", dbDSNFor(name))
+	if err != nil {
+		t.Fatalf("open migration connection: %v", err)
+	}
+	src, err := iofs.New(migrations.FS(), ".")
+	if err != nil {
+		t.Fatalf("migration source: %v", err)
+	}
+	target, err := src.First()
+	if err != nil {
+		t.Fatalf("first migration: %v", err)
+	}
+	if target > version {
+		t.Fatalf("no migration at or below %d", version)
+	}
+	for {
+		next, err := src.Next(target)
+		if errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("migration after %d: %v", target, err)
+		}
+		if next > version {
+			break
+		}
+		target = next
+	}
+	driver, err := mysql.WithInstance(migrationDB, &mysql.Config{})
+	if err != nil {
+		t.Fatalf("migration driver: %v", err)
+	}
+	m, err := migrate.NewWithInstance("iofs", src, "mysql", driver)
+	if err != nil {
+		t.Fatalf("migration instance: %v", err)
+	}
+	t.Cleanup(func() {
+		sourceErr, databaseErr := m.Close()
+		if sourceErr != nil {
+			t.Errorf("close migration source: %v", sourceErr)
+		}
+		if databaseErr != nil {
+			t.Errorf("close migration database: %v", databaseErr)
+		}
+	})
+	if err := m.Migrate(target); err != nil && err != migrate.ErrNoChange {
+		t.Fatalf("migrate to %d (resolved as %d): %v", version, target, err)
+	}
+}
+
+func widenAPKPackageName(t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, statement := range []string{
+		"DROP INDEX idx_apk_version_package ON apk_versions",
+		"ALTER TABLE apk_versions MODIFY package_name VARCHAR(1024) NOT NULL",
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("prepare wide package_name with %q: %v", statement, err)
+		}
+	}
+}
+
+func setMigrationState(t *testing.T, db *sql.DB, version uint, dirty bool) {
+	t.Helper()
+	if _, err := db.Exec("UPDATE schema_migrations SET version = ?, dirty = ?", version, dirty); err != nil {
+		t.Fatalf("set migration state: %v", err)
+	}
+}
+
+func assertMigrationState(t *testing.T, db *sql.DB, wantVersion uint, wantDirty bool) {
+	t.Helper()
+	var version uint
+	var dirty bool
+	if err := db.QueryRow("SELECT version, dirty FROM schema_migrations").Scan(&version, &dirty); err != nil {
+		t.Fatalf("migration state: %v", err)
+	}
+	if version != wantVersion || dirty != wantDirty {
+		t.Fatalf("migration state=(%d,%t), want (%d,%t)", version, dirty, wantVersion, wantDirty)
+	}
+}
+
+func addSemverColumns(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`
+		ALTER TABLE apk_versions
+		  ADD COLUMN version_major BIGINT UNSIGNED NOT NULL DEFAULT 0,
+		  ADD COLUMN version_minor BIGINT UNSIGNED NOT NULL DEFAULT 0,
+		  ADD COLUMN version_patch BIGINT UNSIGNED NOT NULL DEFAULT 0
+	`)
+	if err != nil {
+		t.Fatalf("add semver columns: %v", err)
+	}
+}
+
+func insertAPKVersion(t *testing.T, db *sql.DB, version, token string) {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO apk_versions (version, file_name, file_path, package_name, download_token)
+		VALUES (?, 'app.apk', '/tmp/app.apk', 'com.example.production', ?)
+	`, version, token); err != nil {
+		t.Fatalf("insert APK version %q: %v", version, err)
+	}
 }
 
 func TestMigrateEmptyDB(t *testing.T) {
@@ -116,5 +272,433 @@ func TestDestructiveReset(t *testing.T) {
 	}
 	if count > 0 || count2 > 0 {
 		t.Logf("after migration 003, stats=%d logs=%d", count, count2)
+	}
+}
+
+func TestMigrateWideAPKPackageName(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	widenAPKPackageName(t, db)
+
+	if err := Migrate(context.Background(), db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	var prefix sql.NullInt64
+	if err := db.QueryRow(`
+		SELECT SUB_PART
+		FROM information_schema.STATISTICS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'apk_versions'
+		  AND INDEX_NAME = 'idx_apk_latest'
+		  AND SEQ_IN_INDEX = 1
+	`).Scan(&prefix); err != nil {
+		t.Fatalf("read index prefix: %v", err)
+	}
+	if !prefix.Valid || prefix.Int64 != 191 {
+		t.Fatalf("package_name prefix=%v, want 191", prefix)
+	}
+}
+
+func TestMigrateRepairsDirtyAPKSemverMigration(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	widenAPKPackageName(t, db)
+	if _, err := db.Exec(`
+		INSERT INTO apk_versions (version, file_name, file_path, package_name, download_token)
+		VALUES ('1.2.10', 'app.apk', '/tmp/app.apk', 'com.example.production', 'migration-repair-token')
+	`); err != nil {
+		t.Fatalf("insert APK: %v", err)
+	}
+	addSemverColumns(t, db)
+	setMigrationState(t, db, 5, true)
+
+	if err := Migrate(context.Background(), db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	assertMigrationState(t, db, 8, false)
+	var major, minor, patch uint64
+	if err := db.QueryRow(`
+		SELECT version_major, version_minor, version_patch
+		FROM apk_versions WHERE download_token = 'migration-repair-token'
+	`).Scan(&major, &minor, &patch); err != nil {
+		t.Fatalf("read repaired semver: %v", err)
+	}
+	if major != 1 || minor != 2 || patch != 10 {
+		t.Fatalf("repaired semver=%d.%d.%d, want 1.2.10", major, minor, patch)
+	}
+	var prefix sql.NullInt64
+	if err := db.QueryRow(`
+		SELECT SUB_PART
+		FROM information_schema.STATISTICS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'apk_versions'
+		  AND INDEX_NAME = 'idx_apk_latest'
+		  AND SEQ_IN_INDEX = 1
+	`).Scan(&prefix); err != nil {
+		t.Fatalf("read repaired index prefix: %v", err)
+	}
+	if !prefix.Valid || prefix.Int64 != 191 {
+		t.Fatalf("repaired package_name prefix=%v, want 191", prefix)
+	}
+}
+
+func TestMigrateDoesNotRepairOtherDirtyVersion(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	setMigrationState(t, db, 4, true)
+
+	err := Migrate(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "Dirty database version 4") {
+		t.Fatalf("Migrate error=%v, want dirty version 4", err)
+	}
+	assertMigrationState(t, db, 4, true)
+}
+
+func TestMigrateRejectsDirtyAPKSemverWithoutColumns(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	setMigrationState(t, db, 5, true)
+
+	err := Migrate(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "expected 3 semver columns, found 0") {
+		t.Fatalf("Migrate error=%v, want missing-column diagnostic", err)
+	}
+	assertMigrationState(t, db, 5, true)
+}
+
+func TestMigrateRejectsIncompatibleAPKLatestIndex(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	addSemverColumns(t, db)
+	if _, err := db.Exec("CREATE INDEX idx_apk_latest ON apk_versions(id)"); err != nil {
+		t.Fatalf("create incompatible index: %v", err)
+	}
+	setMigrationState(t, db, 5, true)
+
+	err := Migrate(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "idx_apk_latest has incompatible columns") {
+		t.Fatalf("Migrate error=%v, want incompatible-index diagnostic", err)
+	}
+	assertMigrationState(t, db, 5, true)
+}
+
+func TestMigrateRejectsIncompatibleAPKLatestIndexPrefix(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	addSemverColumns(t, db)
+	if _, err := db.Exec(`
+		CREATE INDEX idx_apk_latest ON apk_versions(
+		  package_name(100), is_active, version_major, version_minor, version_patch, id
+		)
+	`); err != nil {
+		t.Fatalf("create wrong-prefix index: %v", err)
+	}
+	setMigrationState(t, db, 5, true)
+
+	err := Migrate(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "idx_apk_latest has incompatible package_name prefix") {
+		t.Fatalf("Migrate error=%v, want incompatible-prefix diagnostic", err)
+	}
+	assertMigrationState(t, db, 5, true)
+}
+
+func TestMigrateRejectsIncompatibleAPKSemverColumns(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	if _, err := db.Exec(`
+		ALTER TABLE apk_versions
+		  ADD COLUMN version_major INT UNSIGNED NOT NULL DEFAULT 0,
+		  ADD COLUMN version_minor BIGINT NULL DEFAULT 0,
+		  ADD COLUMN version_patch BIGINT UNSIGNED NOT NULL DEFAULT 1
+	`); err != nil {
+		t.Fatalf("add incompatible semver columns: %v", err)
+	}
+	setMigrationState(t, db, 5, true)
+
+	err := Migrate(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "semver columns have incompatible definitions") {
+		t.Fatalf("Migrate error=%v, want incompatible-semver-column diagnostic", err)
+	}
+	assertMigrationState(t, db, 5, true)
+}
+
+func TestMigrateFailsClosedWhenAdvisoryLockIsHeld(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	ctx := context.Background()
+
+	lockConn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("lock connection: %v", err)
+	}
+	locked := true
+	t.Cleanup(func() {
+		if locked {
+			var released sql.NullInt64
+			if err := lockConn.QueryRowContext(context.Background(), "SELECT RELEASE_LOCK(?)", lockID).Scan(&released); err != nil {
+				t.Errorf("cleanup release lock: %v", err)
+			}
+		}
+		lockConn.Close()
+	})
+	var acquired int
+	if err := lockConn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", lockID).Scan(&acquired); err != nil {
+		t.Fatalf("hold advisory lock: %v", err)
+	}
+	if acquired != 1 {
+		t.Fatalf("hold advisory lock result=%d, want 1", acquired)
+	}
+
+	err = Migrate(ctx, db)
+	if err == nil || !strings.Contains(err.Error(), "advisory lock is already held") {
+		t.Fatalf("Migrate error=%v, want held-lock diagnostic", err)
+	}
+	assertMigrationState(t, db, 3, false)
+
+	var released sql.NullInt64
+	if err := lockConn.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", lockID).Scan(&released); err != nil {
+		t.Fatalf("release advisory lock: %v", err)
+	}
+	if !released.Valid || released.Int64 != 1 {
+		t.Fatalf("release advisory lock result=%v, want 1", released)
+	}
+	locked = false
+	if err := Migrate(ctx, db); err != nil {
+		t.Fatalf("Migrate after release: %v", err)
+	}
+	assertMigrationState(t, db, 8, false)
+}
+
+func TestMigrateReleasesDriverConnections(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	db.SetMaxOpenConns(4)
+
+	for i := 0; i < 3; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := Migrate(ctx, db)
+		cancel()
+		if err != nil {
+			t.Fatalf("Migrate call %d: %v", i+1, err)
+		}
+		if stats := db.Stats(); stats.InUse != 0 {
+			t.Fatalf("Migrate call %d left %d connections in use", i+1, stats.InUse)
+		}
+	}
+
+	var one int
+	if err := db.QueryRow("SELECT 1").Scan(&one); err != nil {
+		t.Fatalf("caller-owned database is closed: %v", err)
+	}
+	if one != 1 {
+		t.Fatalf("SELECT 1=%d, want 1", one)
+	}
+}
+
+func TestMigrateRejectsCleanAPKSemverOverflow(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	const version = "18446744073709551616.2.3"
+	insertAPKVersion(t, db, version, "clean-overflow-token")
+
+	err := Migrate(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "semver component exceeds unsigned BIGINT maximum") {
+		t.Fatalf("Migrate error=%v, want semver-overflow diagnostic", err)
+	}
+	assertMigrationState(t, db, 5, true)
+	var gotVersion string
+	if err := db.QueryRow("SELECT version FROM apk_versions WHERE download_token = 'clean-overflow-token'").Scan(&gotVersion); err != nil {
+		t.Fatalf("read overflow APK: %v", err)
+	}
+	if gotVersion != version {
+		t.Fatalf("version=%q, want unchanged %q", gotVersion, version)
+	}
+}
+
+func TestMigrateRejectsDirtyAPKSemverOverflow(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	const version = "1.18446744073709551616.3"
+	insertAPKVersion(t, db, version, "dirty-overflow-token")
+	addSemverColumns(t, db)
+	setMigrationState(t, db, 5, true)
+
+	err := Migrate(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "semver component exceeds unsigned BIGINT maximum") {
+		t.Fatalf("Migrate error=%v, want semver-overflow diagnostic", err)
+	}
+	assertMigrationState(t, db, 5, true)
+	var gotVersion string
+	var major, minor, patch uint64
+	if err := db.QueryRow(`
+		SELECT version, version_major, version_minor, version_patch
+		FROM apk_versions WHERE download_token = 'dirty-overflow-token'
+	`).Scan(&gotVersion, &major, &minor, &patch); err != nil {
+		t.Fatalf("read dirty overflow APK: %v", err)
+	}
+	if gotVersion != version || major != 0 || minor != 0 || patch != 0 {
+		t.Fatalf("overflow APK=(%q,%d.%d.%d), want unchanged (%q,0.0.0)", gotVersion, major, minor, patch, version)
+	}
+}
+
+func TestMigrateAcceptsCleanAPKSemverUint64Max(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	insertAPKVersion(t, db, "18446744073709551615.0.18446744073709551615", "clean-max-token")
+
+	if err := Migrate(context.Background(), db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	assertMigrationState(t, db, 8, false)
+	var major, patch uint64
+	if err := db.QueryRow(`
+		SELECT version_major, version_patch FROM apk_versions
+		WHERE download_token = 'clean-max-token'
+	`).Scan(&major, &patch); err != nil {
+		t.Fatalf("read max-boundary APK: %v", err)
+	}
+	if major != ^uint64(0) || patch != ^uint64(0) {
+		t.Fatalf("max-boundary components=(%d,%d), want (%d,%d)", major, patch, ^uint64(0), ^uint64(0))
+	}
+}
+
+func TestMigrateAcceptsDirtyAPKSemverUint64Max(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	insertAPKVersion(t, db, "0.18446744073709551615.0", "dirty-max-token")
+	addSemverColumns(t, db)
+	setMigrationState(t, db, 5, true)
+
+	if err := Migrate(context.Background(), db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	assertMigrationState(t, db, 8, false)
+	var minor uint64
+	if err := db.QueryRow(`
+		SELECT version_minor FROM apk_versions WHERE download_token = 'dirty-max-token'
+	`).Scan(&minor); err != nil {
+		t.Fatalf("read repaired max-boundary APK: %v", err)
+	}
+	if minor != ^uint64(0) {
+		t.Fatalf("max-boundary minor=%d, want %d", minor, ^uint64(0))
+	}
+}
+
+func TestMigrateRejectsIgnoredAPKLatestIndex(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	addSemverColumns(t, db)
+	if _, err := db.Exec(`
+		CREATE INDEX idx_apk_latest ON apk_versions(
+		  package_name(191), is_active, version_major, version_minor, version_patch, id
+		)
+	`); err != nil {
+		t.Fatalf("create compatible index: %v", err)
+	}
+	if _, err := db.Exec("ALTER TABLE apk_versions ALTER INDEX idx_apk_latest IGNORED"); err != nil {
+		t.Fatalf("ignore compatible index: %v", err)
+	}
+	setMigrationState(t, db, 5, true)
+
+	err := Migrate(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "idx_apk_latest is ignored") {
+		t.Fatalf("Migrate error=%v, want ignored-index diagnostic", err)
+	}
+	assertMigrationState(t, db, 5, true)
+	var ignored string
+	if err := db.QueryRow(`
+		SELECT IGNORED FROM information_schema.STATISTICS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'apk_versions'
+		  AND INDEX_NAME = 'idx_apk_latest'
+		LIMIT 1
+	`).Scan(&ignored); err != nil {
+		t.Fatalf("read ignored index status: %v", err)
+	}
+	if ignored != "YES" {
+		t.Fatalf("index ignored=%q, want unchanged YES", ignored)
+	}
+}
+
+func TestMigrateAcceptsCompatibleAPKLatestIndex(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	insertAPKVersion(t, db, "2.4.6", "compatible-index-token")
+	addSemverColumns(t, db)
+	if _, err := db.Exec(`
+		CREATE INDEX idx_apk_latest ON apk_versions(
+		  package_name(191), is_active, version_major, version_minor, version_patch, id
+		)
+	`); err != nil {
+		t.Fatalf("create compatible index: %v", err)
+	}
+	setMigrationState(t, db, 5, true)
+
+	if err := Migrate(context.Background(), db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	assertMigrationState(t, db, 8, false)
+	var major, minor, patch uint64
+	if err := db.QueryRow(`
+		SELECT version_major, version_minor, version_patch
+		FROM apk_versions WHERE download_token = 'compatible-index-token'
+	`).Scan(&major, &minor, &patch); err != nil {
+		t.Fatalf("read repaired semver: %v", err)
+	}
+	if major != 2 || minor != 4 || patch != 6 {
+		t.Fatalf("repaired semver=%d.%d.%d, want 2.4.6", major, minor, patch)
+	}
+}
+
+func TestMigrateRepairsDirtyAPKSemverWithSingleConnection(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	migrateTestDBTo(t, db, 4)
+	insertAPKVersion(t, db, "3.5.8", "single-connection-repair-token")
+	addSemverColumns(t, db)
+	setMigrationState(t, db, 5, true)
+	db.SetMaxOpenConns(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := Migrate(ctx, db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	assertMigrationState(t, db, 8, false)
+	var major, minor, patch uint64
+	if err := db.QueryRow(`
+		SELECT version_major, version_minor, version_patch
+		FROM apk_versions WHERE download_token = 'single-connection-repair-token'
+	`).Scan(&major, &minor, &patch); err != nil {
+		t.Fatalf("read repaired semver: %v", err)
+	}
+	if major != 3 || minor != 5 || patch != 8 {
+		t.Fatalf("repaired semver=%d.%d.%d, want 3.5.8", major, minor, patch)
+	}
+	if stats := db.Stats(); stats.InUse != 0 {
+		t.Fatalf("Migrate left %d connections in use", stats.InUse)
+	}
+	var one int
+	if err := db.QueryRow("SELECT 1").Scan(&one); err != nil {
+		t.Fatalf("caller-owned database is unusable: %v", err)
+	}
+}
+
+func TestMigrateCleanDBWithSingleConnection(t *testing.T) {
+	db := openIsolatedMigrationDB(t)
+	db.SetMaxOpenConns(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := Migrate(ctx, db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	assertMigrationState(t, db, 8, false)
+	if stats := db.Stats(); stats.InUse != 0 {
+		t.Fatalf("Migrate left %d connections in use", stats.InUse)
+	}
+	var one int
+	if err := db.QueryRow("SELECT 1").Scan(&one); err != nil {
+		t.Fatalf("caller-owned database is unusable: %v", err)
 	}
 }

--- a/migrations/000005_apk_semver_order.up.sql
+++ b/migrations/000005_apk_semver_order.up.sql
@@ -3,11 +3,31 @@ DROP PROCEDURE IF EXISTS check_semver_preflight;
 CREATE PROCEDURE check_semver_preflight()
 BEGIN
   DECLARE invalid_count INT;
+  DECLARE overflow_count INT;
   SELECT COUNT(*) INTO invalid_count FROM apk_versions
   WHERE `version` NOT REGEXP '^[0-9]+\\.[0-9]+\\.[0-9]+$';
   IF invalid_count > 0 THEN
     SIGNAL SQLSTATE '45000'
       SET MESSAGE_TEXT = 'preflight: apk_versions contains non-semver version strings. All versions must match MAJOR.MINOR.PATCH (non-negative integers only).';
+  END IF;
+
+  SELECT COUNT(*) INTO overflow_count
+  FROM (
+    SELECT
+      SUBSTRING_INDEX(`version`, '.', 1) AS semver_major,
+      SUBSTRING_INDEX(SUBSTRING_INDEX(`version`, '.', 2), '.', -1) AS semver_minor,
+      SUBSTRING_INDEX(`version`, '.', -1) AS semver_patch
+    FROM apk_versions
+  ) AS semver_parts
+  WHERE CHAR_LENGTH(semver_major) > 20
+     OR (CHAR_LENGTH(semver_major) = 20 AND BINARY semver_major > BINARY '18446744073709551615')
+     OR CHAR_LENGTH(semver_minor) > 20
+     OR (CHAR_LENGTH(semver_minor) = 20 AND BINARY semver_minor > BINARY '18446744073709551615')
+     OR CHAR_LENGTH(semver_patch) > 20
+     OR (CHAR_LENGTH(semver_patch) = 20 AND BINARY semver_patch > BINARY '18446744073709551615');
+  IF overflow_count > 0 THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'preflight: apk_versions semver component exceeds unsigned BIGINT maximum 18446744073709551615.';
   END IF;
 END;
 
@@ -24,4 +44,4 @@ UPDATE apk_versions SET
   version_minor = CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(`version`, '.', 2), '.', -1) AS UNSIGNED),
   version_patch = CAST(SUBSTRING_INDEX(`version`, '.', -1) AS UNSIGNED);
 
-CREATE INDEX idx_apk_latest ON apk_versions(package_name, is_active, version_major, version_minor, version_patch, id);
+CREATE INDEX idx_apk_latest ON apk_versions(package_name(191), is_active, version_major, version_minor, version_patch, id);


### PR DESCRIPTION
## Summary
- bound `idx_apk_latest` with a safe `package_name(191)` prefix
- repair only the observed `version=5, dirty=true` partial schema and fail closed for incompatible states
- serialize migrations on one checked MariaDB connection and validate semver bounds/index metadata before `Force(5)`
- add isolated MariaDB regression coverage and operational guidance

## Production failure
Migration 5 failed with MariaDB error 1071 because the production `package_name` definition made the composite key exceed 3072 bytes. The failed DDL left the three semver columns present and `schema_migrations` dirty at version 5.

## Testing
- MariaDB 11 integration suite: `go test -tags=integration -count=1 -p 1 -timeout 300s ./internal/platform/database`
- `go test -count=1 -timeout 120s ./...`
- `go vet ./...`
- `test -z "$(gofmt -l .)"`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database migration recovery for a specific dirty migration state.
  - Prevented migration failures caused by oversized indexes and invalid semver values.
  - Added safe validation for semver column definitions, index compatibility, and numeric boundaries.
  - Migrations now fail safely when recovery conditions are not met.

- **Documentation**
  - Added operator guidance for automatic recovery, readiness verification, and required follow-up actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->