### PR TITLE
fix(frontend): use same-origin API by default

### DIFF
--- a/web/src/constants.spec.ts
+++ b/web/src/constants.spec.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
-
-import { API_BASE_URL } from "./constants";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("API_BASE_URL", () => {
-  it("defaults to the same-origin web API", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("defaults to the same-origin web API", async () => {
+    vi.stubEnv("VITE_API_BASE_URL", undefined);
+    const { API_BASE_URL } = await import("./constants");
+
     expect(API_BASE_URL).toBe("/api/web/v1");
   });
 });

--- a/web/src/constants.spec.ts
+++ b/web/src/constants.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { API_BASE_URL } from "./constants";
+
+describe("API_BASE_URL", () => {
+  it("defaults to the same-origin web API", () => {
+    expect(API_BASE_URL).toBe("/api/web/v1");
+  });
+});

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,3 +1,3 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080/api/web/v1";
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "/api/web/v1";
 export const KEY_USER_LOGIN = "user_info";
 export const KEY_THEME = "local_theme";

--- a/web/vite.config.spec.ts
+++ b/web/vite.config.spec.ts
@@ -1,0 +1,19 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import config from "./vite.config";
+
+describe("Vite development server", () => {
+  it("proxies API requests to the default backend", () => {
+    expect(config).toMatchObject({
+      server: {
+        proxy: {
+          "/api": {
+            target: "http://localhost:8080",
+          },
+        },
+      },
+    });
+  });
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+      },
+    },
+  },
   optimizeDeps: {
     include: ["protobufjs/minimal"],
   },


### PR DESCRIPTION
## Summary
- default the web API base URL to the same origin instead of localhost:8080
- preserve VITE_API_BASE_URL as an explicit development override
- add a regression test for the production fallback

## Verification
- npm run test:unit -- --run
- npm run lint
- npm run build
- verified the production bundle contains /api/web/v1 and no localhost:8080 reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the web application’s default API endpoint to use the current site’s API path, improving compatibility across deployment environments.

* **Tests**
  * Added coverage to verify the default API endpoint is set correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->