### PR TITLE
fix(events): serve team logos locally

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -105,6 +105,12 @@ func New(cfg config.Config) (*App, error) {
 }
 
 func (a *App) Run(ctx context.Context) error {
+	if a.DB != nil {
+		if err := events.NewRepository(a.DB).ReconcileTeamLogos(ctx); err != nil {
+			return err
+		}
+	}
+
 	scrapeSvc, aggRepo := buildSchedulerDeps(a.DB, a.batchSize, a.concur, events.NewEpochStore(a.Redis), a.logger)
 	a.Scheduler.Init(a.DB, scrapeSvc, aggRepo, redisplatform.NewLocker(a.Redis))
 	a.Scheduler.SetCleanupJob(buildCleanupJobFromApp(a), a.Redis)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,17 +24,18 @@ import (
 )
 
 type App struct {
-	HTTP        *http.Server
-	Pprof       *http.Server
-	Scheduler   *scheduler.Scheduler
-	DB          *gorm.DB
-	SQL         *sql.DB
-	Redis       *goredis.Client
-	ready       atomic.Bool
-	batchSize   int
-	concur      int
-	storagePath string
-	logger      *slog.Logger
+	HTTP          *http.Server
+	Pprof         *http.Server
+	Scheduler     *scheduler.Scheduler
+	DB            *gorm.DB
+	SQL           *sql.DB
+	Redis         *goredis.Client
+	logoScheduler events.TeamLogoScheduler
+	ready         atomic.Bool
+	batchSize     int
+	concur        int
+	storagePath   string
+	logger        *slog.Logger
 }
 
 func (a *App) IsReady() bool {
@@ -72,23 +73,25 @@ func New(cfg config.Config) (*App, error) {
 	}
 
 	sched := scheduler.New(slog.Default())
+	logoScheduler := events.NewLogoScheduler()
 
 	pprofSrv := observability.NewPprofServer(cfg.PprofAddr)
 
 	app := &App{
-		Scheduler:   sched,
-		DB:          db,
-		SQL:         sqlDB,
-		Redis:       redisClient,
-		Pprof:       pprofSrv,
-		batchSize:   cfg.ScrapeBatchSize,
-		concur:      cfg.ScrapeConcurrency,
-		storagePath: cfg.APKStoragePath,
-		logger:      logger,
+		Scheduler:     sched,
+		DB:            db,
+		SQL:           sqlDB,
+		Redis:         redisClient,
+		logoScheduler: logoScheduler,
+		Pprof:         pprofSrv,
+		batchSize:     cfg.ScrapeBatchSize,
+		concur:        cfg.ScrapeConcurrency,
+		storagePath:   cfg.APKStoragePath,
+		logger:        logger,
 	}
 	app.ready.Store(true)
 
-	router := NewRouter(db, redisClient, cfg, tokens)
+	router := NewRouter(db, redisClient, cfg, tokens, logoScheduler)
 	router.Use(server.ReadinessMiddleware(&app.ready))
 
 	app.HTTP = &http.Server{
@@ -106,12 +109,12 @@ func New(cfg config.Config) (*App, error) {
 
 func (a *App) Run(ctx context.Context) error {
 	if a.DB != nil {
-		if err := events.NewRepository(a.DB).ReconcileTeamLogos(ctx); err != nil {
+		if err := events.NewRepositoryWithLogoScheduler(a.DB, a.logoScheduler).ReconcileTeamLogos(ctx); err != nil {
 			return err
 		}
 	}
 
-	scrapeSvc, aggRepo := buildSchedulerDeps(a.DB, a.batchSize, a.concur, events.NewEpochStore(a.Redis), a.logger)
+	scrapeSvc, aggRepo := buildSchedulerDeps(a.DB, a.batchSize, a.concur, events.NewEpochStore(a.Redis), a.logoScheduler, a.logger)
 	a.Scheduler.Init(a.DB, scrapeSvc, aggRepo, redisplatform.NewLocker(a.Redis))
 	a.Scheduler.SetCleanupJob(buildCleanupJobFromApp(a), a.Redis)
 	a.Scheduler.SetDownloadCounter(apk.NewDownloadCounter(a.Redis, a.DB))

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,13 +2,20 @@ package app
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/jeriveromartinez/sofascore-scrapper/internal/scheduler"
+	"gorm.io/gorm"
 )
 
 func TestGracefulShutdown(t *testing.T) {
@@ -113,4 +120,115 @@ func TestReadinessToggle(t *testing.T) {
 	if app.IsReady() {
 		t.Error("app should not be ready after cancellation")
 	}
+}
+
+func TestShutdownWaitsForLogoSchedulerBeforeClosingSQL(t *testing.T) {
+	closed := make(chan struct{})
+	driverName := fmt.Sprintf("shutdown-order-%d", shutdownDriverSequence.Add(1))
+	sql.Register(driverName, &closeTrackingDriver{closed: closed})
+	sqlDB, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("open tracked SQL connection: %v", err)
+	}
+	if err := sqlDB.Ping(); err != nil {
+		t.Fatalf("ping tracked SQL connection: %v", err)
+	}
+
+	logos := &blockingLogoLifecycle{
+		stopped:         make(chan struct{}),
+		shutdownStarted: make(chan struct{}),
+		release:         make(chan struct{}),
+	}
+	sched := scheduler.New(slog.Default())
+	sched.Init(nil, nil, nil, nil)
+	app := &App{
+		HTTP:          &http.Server{},
+		Scheduler:     sched,
+		SQL:           sqlDB,
+		logoScheduler: logos,
+		logger:        slog.Default(),
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- app.shutdown() }()
+	select {
+	case <-logos.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("logo scheduler did not stop accepting work")
+	}
+	select {
+	case <-logos.shutdownStarted:
+	case <-time.After(time.Second):
+		t.Fatal("logo scheduler shutdown did not start")
+	}
+	select {
+	case <-closed:
+		t.Fatal("SQL closed before logo scheduler shutdown finished")
+	default:
+	}
+
+	close(logos.release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("shutdown returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("application shutdown did not finish")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("SQL did not close after logo scheduler shutdown")
+	}
+}
+
+var shutdownDriverSequence atomic.Uint64
+
+type blockingLogoLifecycle struct {
+	stopOnce        sync.Once
+	shutdownOnce    sync.Once
+	stopped         chan struct{}
+	shutdownStarted chan struct{}
+	release         chan struct{}
+}
+
+func (s *blockingLogoLifecycle) Stop() {
+	s.stopOnce.Do(func() { close(s.stopped) })
+}
+
+func (s *blockingLogoLifecycle) Schedule(*gorm.DB, int64, string) {}
+
+func (s *blockingLogoLifecycle) Shutdown(ctx context.Context) {
+	s.shutdownOnce.Do(func() { close(s.shutdownStarted) })
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+	}
+}
+
+type closeTrackingDriver struct {
+	closed chan struct{}
+}
+
+func (d *closeTrackingDriver) Open(string) (driver.Conn, error) {
+	return &closeTrackingConn{closed: d.closed}, nil
+}
+
+type closeTrackingConn struct {
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+func (c *closeTrackingConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return nil
+}
+
+func (c *closeTrackingConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not implemented")
 }

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -21,7 +21,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func NewRouter(db *gorm.DB, redisClient *goredis.Client, cfg config.Config, tokens *auth.TokenService) *gin.Engine {
+func NewRouter(db *gorm.DB, redisClient *goredis.Client, cfg config.Config, tokens *auth.TokenService, logoScheduler events.TeamLogoScheduler) *gin.Engine {
 	if cfg.ScrapeBatchSize <= 0 {
 		cfg.ScrapeBatchSize = 500
 	}
@@ -105,7 +105,7 @@ func NewRouter(db *gorm.DB, redisClient *goredis.Client, cfg config.Config, toke
 	statsHandler := reporting.NewStatsHandler(reportingRepo)
 	statsHandler.RegisterRoutes(webV1, reporting.StatsHandlerDeps{AuthMiddleware: adminThenRl})
 
-	eventsRepo := events.NewRepository(db)
+	eventsRepo := events.NewRepositoryWithLogoScheduler(db, logoScheduler)
 	eventsCache := events.NewCurrentEventsCache(redisClient)
 	eventsEpoch := events.NewEpochStore(redisClient)
 	eventsService := events.NewService(eventsRepo, eventsCache, eventsEpoch)
@@ -155,12 +155,12 @@ func NewRouter(db *gorm.DB, redisClient *goredis.Client, cfg config.Config, toke
 	return router
 }
 
-func buildSchedulerDeps(db *gorm.DB, batchSize int, concurrency int, epoch *events.EpochStore, logger *slog.Logger) (*scraper.Service, *reporting.AggregationRepository) {
+func buildSchedulerDeps(db *gorm.DB, batchSize int, concurrency int, epoch *events.EpochStore, logoScheduler events.TeamLogoScheduler, logger *slog.Logger) (*scraper.Service, *reporting.AggregationRepository) {
 	client, err := scraper.NewClient(scraper.ClientConfig{})
 	if err != nil {
 		panic("scraper: failed to create client: " + err.Error())
 	}
-	eventsRepo := events.NewRepository(db)
+	eventsRepo := events.NewRepositoryWithLogoScheduler(db, logoScheduler)
 	scrapeSvc, err := scraper.NewService(eventsRepo, client, batchSize, concurrency, logger)
 	if err != nil {
 		panic("scraper: failed to create service: " + err.Error())

--- a/internal/app/routes_test.go
+++ b/internal/app/routes_test.go
@@ -80,7 +80,7 @@ func newTestRouter(t *testing.T, cfg config.Config) *gin.Engine {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewRouter(nil, nil, cfg, tokens)
+	return NewRouter(nil, nil, cfg, tokens, nil)
 }
 
 func TestCrashReportInheritsOneMiBBodyLimit(t *testing.T) {
@@ -142,7 +142,7 @@ func TestAdminRateLimitRunsBeforeProtectedHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	router := NewRouter(nil, nil, config.Config{JWTSecret: "test-secret"}, tokens)
+	router := NewRouter(nil, nil, config.Config{JWTSecret: "test-secret"}, tokens, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/web/v1/apk/uploads", bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Content-Type", "application/x-protobuf")
@@ -160,7 +160,7 @@ func TestRouteCompatibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg := config.Config{JWTSecret: "test-secret"}
-	router := NewRouter(nil, nil, cfg, tokens)
+	router := NewRouter(nil, nil, cfg, tokens, nil)
 	got := make(map[string]bool)
 	for _, route := range router.Routes() {
 		got[route.Method+" "+route.Path] = true

--- a/internal/app/shutdown.go
+++ b/internal/app/shutdown.go
@@ -14,6 +14,9 @@ func (a *App) shutdown() error {
 	a.logger.Info("shutting down application")
 
 	a.ready.Store(false)
+	if a.logoScheduler != nil {
+		a.logoScheduler.Stop()
+	}
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -31,6 +34,9 @@ func (a *App) shutdown() error {
 	}
 
 	a.Scheduler.Shutdown()
+	if a.logoScheduler != nil {
+		a.logoScheduler.Shutdown(shutdownCtx)
+	}
 
 	if a.Redis != nil {
 		if err := a.Redis.Close(); err != nil {

--- a/internal/events/batch_integration_test.go
+++ b/internal/events/batch_integration_test.go
@@ -5,6 +5,9 @@ package events
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -269,6 +272,47 @@ func TestUpsertScrapeBatch_PersistsLocalLogoURLAndSchedulesRemoteSource(t *testi
 	}
 	if len(scheduled) != 1 || scheduled[0].teamID != 10 || scheduled[0].sourceURL != remoteURL {
 		t.Fatalf("scheduled = %#v, want team 10 from %q", scheduled, remoteURL)
+	}
+}
+
+func TestReconcileTeamLogosNormalizesRowsAndSchedulesMissingFiles(t *testing.T) {
+	db := setupBatchTestDB(t)
+	storage := t.TempDir()
+	t.Setenv("IMAGE_STORAGE_PATH", storage)
+
+	remote := Team{TeamId: 10, Name: "Remote", LogoUrl: TeamLogoSourceURL(10)}
+	cached := Team{TeamId: 20, Name: "Cached", LogoUrl: TeamLogoSourceURL(20)}
+	if err := db.Create(&[]Team{remote, cached}).Error; err != nil {
+		t.Fatalf("seed teams: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(TeamLogoLocalPath(20)), 0o755); err != nil {
+		t.Fatalf("create logo dir: %v", err)
+	}
+	if err := os.WriteFile(TeamLogoLocalPath(20), []byte("cached"), 0o644); err != nil {
+		t.Fatalf("write cached logo: %v", err)
+	}
+
+	repo := NewRepository(db)
+	var scheduled []int64
+	repo.scheduleLogo = func(_ *gorm.DB, teamID int64, sourceURL string) {
+		scheduled = append(scheduled, teamID)
+		if sourceURL != TeamLogoSourceURL(teamID) {
+			t.Errorf("source URL = %q for team %d", sourceURL, teamID)
+		}
+	}
+	if err := repo.ReconcileTeamLogos(context.Background()); err != nil {
+		t.Fatalf("ReconcileTeamLogos: %v", err)
+	}
+
+	var teams []Team
+	if err := db.Order("team_id").Find(&teams).Error; err != nil {
+		t.Fatalf("load teams: %v", err)
+	}
+	if teams[0].LogoUrl != "/teams/logo/10" || teams[1].LogoUrl != "/teams/logo/20" {
+		t.Fatalf("reconciled teams = %#v", teams)
+	}
+	if !reflect.DeepEqual(scheduled, []int64{10}) {
+		t.Fatalf("scheduled = %v, want [10]", scheduled)
 	}
 }
 

--- a/internal/events/batch_integration_test.go
+++ b/internal/events/batch_integration_test.go
@@ -233,37 +233,42 @@ func TestUpsertScrapeBatch_RollbackOnFailure(t *testing.T) {
 	}
 }
 
-func TestUpsertScrapeBatch_LogoURLNotUpdated(t *testing.T) {
+func TestUpsertScrapeBatch_PersistsLocalLogoURLAndSchedulesRemoteSource(t *testing.T) {
 	db := setupBatchTestDB(t)
 	repo := NewRepository(db)
 
-	proxiedURL := "/teams/logo/10"
+	const remoteURL = "https://img.sofascore.com/api/v1/team/10/image"
+	if err := db.Create(&Team{TeamId: 10, Name: "Old", LogoUrl: remoteURL}).Error; err != nil {
+		t.Fatalf("seed team: %v", err)
+	}
+
+	type scheduledLogo struct {
+		teamID    int64
+		sourceURL string
+	}
+	var scheduled []scheduledLogo
+	repo.scheduleLogo = func(_ *gorm.DB, teamID int64, sourceURL string) {
+		scheduled = append(scheduled, scheduledLogo{teamID: teamID, sourceURL: sourceURL})
+	}
+
 	batch := ScrapeBatch{
-		Teams:       []Team{{TeamId: 10, Name: "Team", LogoUrl: "https://img.sofascore.com/api/v1/team/10/image"}},
+		Teams:       []Team{{TeamId: 10, Name: "Updated", LogoUrl: remoteURL}},
 		Tournaments: []tournaments.Tournament{testTournament(1)},
 		Events:      []Event{testEvent(1, 10, 10)},
 	}
-
 	if err := repo.UpsertScrapeBatch(context.Background(), batch, 500); err != nil {
-		t.Fatalf("first UpsertScrapeBatch: %v", err)
-	}
-
-	db.Model(&Team{}).Where("team_id = ?", 10).Update("logo_url", proxiedURL)
-
-	batch2 := ScrapeBatch{
-		Teams:       []Team{{TeamId: 10, Name: "Team Updated", LogoUrl: "https://img.sofascore.com/api/v1/team/10/image", PrimaryColor: "#111"}},
-		Tournaments: []tournaments.Tournament{testTournament(1)},
-		Events:      []Event{{SofaScoreEventId: 1, Sport: "football", HomeTeamId: 10, AwayTeamId: 10, ScrapedAt: 2000, Slug: "x", LeagueId: 1, StatusType: "finished"}},
-	}
-
-	if err := repo.UpsertScrapeBatch(context.Background(), batch2, 500); err != nil {
-		t.Fatalf("second UpsertScrapeBatch: %v", err)
+		t.Fatalf("UpsertScrapeBatch: %v", err)
 	}
 
 	var team Team
-	db.Where("team_id = ?", 10).First(&team)
-	if team.LogoUrl != proxiedURL {
-		t.Errorf("logo_url should not be overwritten by OnConflict upsert: expected %s, got %s", proxiedURL, team.LogoUrl)
+	if err := db.Where("team_id = ?", 10).First(&team).Error; err != nil {
+		t.Fatalf("load team: %v", err)
+	}
+	if team.LogoUrl != "/teams/logo/10" {
+		t.Fatalf("logo URL = %q, want local path", team.LogoUrl)
+	}
+	if len(scheduled) != 1 || scheduled[0].teamID != 10 || scheduled[0].sourceURL != remoteURL {
+		t.Fatalf("scheduled = %#v, want team 10 from %q", scheduled, remoteURL)
 	}
 }
 

--- a/internal/events/logo_scheduler.go
+++ b/internal/events/logo_scheduler.go
@@ -1,0 +1,79 @@
+package events
+
+import "sync"
+
+const logoWorkerCount = 10
+
+type logoScheduler struct {
+	mu       sync.Mutex
+	ready    *sync.Cond
+	pending  map[int64]func()
+	queue    []int64
+	head     int
+	stopping bool
+	workers  sync.WaitGroup
+}
+
+func newLogoScheduler(workerCount int) *logoScheduler {
+	scheduler := &logoScheduler{pending: make(map[int64]func())}
+	scheduler.ready = sync.NewCond(&scheduler.mu)
+	scheduler.workers.Add(workerCount)
+	for range workerCount {
+		go scheduler.run()
+	}
+	return scheduler
+}
+
+func (s *logoScheduler) enqueue(teamID int64, work func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.stopping {
+		return
+	}
+	if _, exists := s.pending[teamID]; exists {
+		return
+	}
+
+	s.pending[teamID] = work
+	s.queue = append(s.queue, teamID)
+	s.ready.Signal()
+}
+
+func (s *logoScheduler) run() {
+	defer s.workers.Done()
+	for {
+		s.mu.Lock()
+		for s.head == len(s.queue) && !s.stopping {
+			s.ready.Wait()
+		}
+		if s.head == len(s.queue) {
+			s.mu.Unlock()
+			return
+		}
+
+		teamID := s.queue[s.head]
+		s.head++
+		work := s.pending[teamID]
+		// Retain the pending entry while active so concurrent duplicates coalesce.
+		if s.head == len(s.queue) {
+			s.queue = nil
+			s.head = 0
+		}
+		s.mu.Unlock()
+
+		work()
+
+		s.mu.Lock()
+		delete(s.pending, teamID)
+		s.mu.Unlock()
+	}
+}
+
+func (s *logoScheduler) shutdown() {
+	s.mu.Lock()
+	s.stopping = true
+	s.ready.Broadcast()
+	s.mu.Unlock()
+	s.workers.Wait()
+}

--- a/internal/events/logo_scheduler.go
+++ b/internal/events/logo_scheduler.go
@@ -1,21 +1,43 @@
 package events
 
-import "sync"
+import (
+	"context"
+	"sync"
+
+	"gorm.io/gorm"
+)
 
 const logoWorkerCount = 10
 
-type logoScheduler struct {
-	mu       sync.Mutex
-	ready    *sync.Cond
-	pending  map[int64]func()
-	queue    []int64
-	head     int
-	stopping bool
-	workers  sync.WaitGroup
+type TeamLogoScheduler interface {
+	Schedule(*gorm.DB, int64, string)
+	Stop()
+	Shutdown(context.Context)
 }
 
-func newLogoScheduler(workerCount int) *logoScheduler {
-	scheduler := &logoScheduler{pending: make(map[int64]func())}
+type LogoScheduler struct {
+	mu         sync.Mutex
+	ready      *sync.Cond
+	pending    map[int64]func(context.Context)
+	queue      []int64
+	head       int
+	stopping   bool
+	workCtx    context.Context
+	cancelWork context.CancelFunc
+	workers    sync.WaitGroup
+}
+
+func NewLogoScheduler() *LogoScheduler {
+	return newLogoScheduler(logoWorkerCount)
+}
+
+func newLogoScheduler(workerCount int) *LogoScheduler {
+	workCtx, cancelWork := context.WithCancel(context.Background())
+	scheduler := &LogoScheduler{
+		pending:    make(map[int64]func(context.Context)),
+		workCtx:    workCtx,
+		cancelWork: cancelWork,
+	}
 	scheduler.ready = sync.NewCond(&scheduler.mu)
 	scheduler.workers.Add(workerCount)
 	for range workerCount {
@@ -24,23 +46,30 @@ func newLogoScheduler(workerCount int) *logoScheduler {
 	return scheduler
 }
 
-func (s *logoScheduler) enqueue(teamID int64, work func()) {
+func (s *LogoScheduler) enqueue(teamID int64, work func(context.Context)) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.stopping {
-		return
+		return false
 	}
 	if _, exists := s.pending[teamID]; exists {
-		return
+		return true
 	}
 
 	s.pending[teamID] = work
 	s.queue = append(s.queue, teamID)
 	s.ready.Signal()
+	return true
 }
 
-func (s *logoScheduler) run() {
+func (s *LogoScheduler) Schedule(db *gorm.DB, teamID int64, sourceURL string) {
+	s.enqueue(teamID, func(ctx context.Context) {
+		downloadAndUpdateTeamLogo(ctx, db.Session(&gorm.Session{}), teamID, sourceURL)
+	})
+}
+
+func (s *LogoScheduler) run() {
 	defer s.workers.Done()
 	for {
 		s.mu.Lock()
@@ -62,7 +91,7 @@ func (s *logoScheduler) run() {
 		}
 		s.mu.Unlock()
 
-		work()
+		work(s.workCtx)
 
 		s.mu.Lock()
 		delete(s.pending, teamID)
@@ -70,10 +99,36 @@ func (s *logoScheduler) run() {
 	}
 }
 
-func (s *logoScheduler) shutdown() {
+func (s *LogoScheduler) Stop() {
 	s.mu.Lock()
+	if s.stopping {
+		s.mu.Unlock()
+		return
+	}
 	s.stopping = true
+	for _, teamID := range s.queue[s.head:] {
+		delete(s.pending, teamID)
+	}
+	s.queue = nil
+	s.head = 0
 	s.ready.Broadcast()
 	s.mu.Unlock()
-	s.workers.Wait()
+}
+
+func (s *LogoScheduler) Shutdown(ctx context.Context) {
+	s.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		s.workers.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		s.cancelWork()
+	case <-ctx.Done():
+		s.cancelWork()
+		<-done
+	}
 }

--- a/internal/events/logo_scheduler_test.go
+++ b/internal/events/logo_scheduler_test.go
@@ -1,0 +1,48 @@
+package events
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+func TestEnqueueTeamLogoDoesNotDropWorkWhenSemaphoreIsFull(t *testing.T) {
+	var group singleflight.Group
+	semaphore := make(chan struct{}, 1)
+	release := make(chan struct{})
+	started := make(chan int64, 3)
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	for teamID := int64(1); teamID <= 3; teamID++ {
+		id := teamID
+		enqueueTeamLogo(&group, semaphore, id, func() {
+			defer wg.Done()
+			started <- id
+			<-release
+		})
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first logo did not start")
+	}
+	close(release)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("queued logos were dropped or blocked forever")
+	}
+	if len(started) != 2 {
+		t.Fatalf("remaining starts = %d, want 2", len(started))
+	}
+}

--- a/internal/events/logo_scheduler_test.go
+++ b/internal/events/logo_scheduler_test.go
@@ -1,48 +1,156 @@
 package events
 
 import (
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
-
-	"golang.org/x/sync/singleflight"
 )
 
-func TestEnqueueTeamLogoDoesNotDropWorkWhenSemaphoreIsFull(t *testing.T) {
-	var group singleflight.Group
-	semaphore := make(chan struct{}, 1)
-	release := make(chan struct{})
-	started := make(chan int64, 3)
-	var wg sync.WaitGroup
-	wg.Add(3)
+func TestLogoSchedulerProcessesWorkBeyondWorkerCount(t *testing.T) {
+	scheduler := newLogoScheduler(logoWorkerCount)
+	t.Cleanup(scheduler.shutdown)
 
-	for teamID := int64(1); teamID <= 3; teamID++ {
+	const total = logoWorkerCount + 5
+	completed := make(chan int64, total)
+	for teamID := int64(1); teamID <= total; teamID++ {
 		id := teamID
-		enqueueTeamLogo(&group, semaphore, id, func() {
-			defer wg.Done()
-			started <- id
+		scheduler.enqueue(id, func() { completed <- id })
+	}
+
+	seen := make(map[int64]bool, total)
+	for range total {
+		select {
+		case teamID := <-completed:
+			seen[teamID] = true
+		case <-time.After(time.Second):
+			t.Fatalf("completed %d unique jobs, want %d", len(seen), total)
+		}
+	}
+	if len(seen) != total {
+		t.Fatalf("completed %d unique jobs, want %d", len(seen), total)
+	}
+}
+
+func TestLogoSchedulerLimitsActiveWork(t *testing.T) {
+	scheduler := newLogoScheduler(logoWorkerCount)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		scheduler.shutdown()
+	})
+
+	const total = logoWorkerCount * 2
+	started := make(chan struct{}, total)
+	completed := make(chan struct{}, total)
+	var active atomic.Int64
+	var maximum atomic.Int64
+	for teamID := int64(1); teamID <= total; teamID++ {
+		scheduler.enqueue(teamID, func() {
+			current := active.Add(1)
+			for observed := maximum.Load(); current > observed && !maximum.CompareAndSwap(observed, current); observed = maximum.Load() {
+			}
+			started <- struct{}{}
 			<-release
+			active.Add(-1)
+			completed <- struct{}{}
 		})
 	}
 
+	for range logoWorkerCount {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("workers did not start")
+		}
+	}
+	select {
+	case <-started:
+		t.Fatalf("more than %d jobs became active", logoWorkerCount)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	for range total {
+		select {
+		case <-completed:
+		case <-time.After(time.Second):
+			t.Fatal("queued jobs did not complete")
+		}
+	}
+	if got := maximum.Load(); got > logoWorkerCount {
+		t.Fatalf("maximum active jobs = %d, want at most %d", got, logoWorkerCount)
+	}
+}
+
+func TestLogoSchedulerCoalescesDuplicateTeamIDs(t *testing.T) {
+	scheduler := newLogoScheduler(logoWorkerCount)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		scheduler.shutdown()
+	})
+
+	started := make(chan struct{})
+	var executions atomic.Int64
+	scheduler.enqueue(1, func() {
+		executions.Add(1)
+		close(started)
+		<-release
+	})
 	select {
 	case <-started:
 	case <-time.After(time.Second):
-		t.Fatal("first logo did not start")
+		t.Fatal("logo job did not start")
 	}
-	close(release)
 
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("queued logos were dropped or blocked forever")
+	for range 100 {
+		scheduler.enqueue(1, func() { executions.Add(1) })
 	}
-	if len(started) != 2 {
-		t.Fatalf("remaining starts = %d, want 2", len(started))
+	releaseOnce.Do(func() { close(release) })
+	scheduler.shutdown()
+
+	if got := executions.Load(); got != 1 {
+		t.Fatalf("duplicate team executed %d times, want 1", got)
 	}
+}
+
+func TestLogoSchedulerQueuedWorkDoesNotCreateGoroutines(t *testing.T) {
+	scheduler := newLogoScheduler(logoWorkerCount)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		scheduler.shutdown()
+	})
+
+	started := make(chan struct{}, logoWorkerCount)
+	for teamID := int64(1); teamID <= logoWorkerCount; teamID++ {
+		scheduler.enqueue(teamID, func() {
+			started <- struct{}{}
+			<-release
+		})
+	}
+	for range logoWorkerCount {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("workers did not start")
+		}
+	}
+
+	before := runtime.NumGoroutine()
+	for teamID := int64(logoWorkerCount + 1); teamID <= 1000; teamID++ {
+		scheduler.enqueue(teamID, func() { <-release })
+	}
+	runtime.Gosched()
+	after := runtime.NumGoroutine()
+	if growth := after - before; growth > 2 {
+		t.Fatalf("queueing jobs added %d goroutines, want no growth tied to queue depth", growth)
+	}
+
+	releaseOnce.Do(func() { close(release) })
 }

--- a/internal/events/logo_scheduler_test.go
+++ b/internal/events/logo_scheduler_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -10,13 +11,13 @@ import (
 
 func TestLogoSchedulerProcessesWorkBeyondWorkerCount(t *testing.T) {
 	scheduler := newLogoScheduler(logoWorkerCount)
-	t.Cleanup(scheduler.shutdown)
+	t.Cleanup(func() { scheduler.Shutdown(context.Background()) })
 
 	const total = logoWorkerCount + 5
 	completed := make(chan int64, total)
 	for teamID := int64(1); teamID <= total; teamID++ {
 		id := teamID
-		scheduler.enqueue(id, func() { completed <- id })
+		scheduler.enqueue(id, func(context.Context) { completed <- id })
 	}
 
 	seen := make(map[int64]bool, total)
@@ -39,7 +40,7 @@ func TestLogoSchedulerLimitsActiveWork(t *testing.T) {
 	var releaseOnce sync.Once
 	t.Cleanup(func() {
 		releaseOnce.Do(func() { close(release) })
-		scheduler.shutdown()
+		scheduler.Shutdown(context.Background())
 	})
 
 	const total = logoWorkerCount * 2
@@ -48,7 +49,7 @@ func TestLogoSchedulerLimitsActiveWork(t *testing.T) {
 	var active atomic.Int64
 	var maximum atomic.Int64
 	for teamID := int64(1); teamID <= total; teamID++ {
-		scheduler.enqueue(teamID, func() {
+		scheduler.enqueue(teamID, func(context.Context) {
 			current := active.Add(1)
 			for observed := maximum.Load(); current > observed && !maximum.CompareAndSwap(observed, current); observed = maximum.Load() {
 			}
@@ -91,12 +92,12 @@ func TestLogoSchedulerCoalescesDuplicateTeamIDs(t *testing.T) {
 	var releaseOnce sync.Once
 	t.Cleanup(func() {
 		releaseOnce.Do(func() { close(release) })
-		scheduler.shutdown()
+		scheduler.Shutdown(context.Background())
 	})
 
 	started := make(chan struct{})
 	var executions atomic.Int64
-	scheduler.enqueue(1, func() {
+	scheduler.enqueue(1, func(context.Context) {
 		executions.Add(1)
 		close(started)
 		<-release
@@ -108,10 +109,10 @@ func TestLogoSchedulerCoalescesDuplicateTeamIDs(t *testing.T) {
 	}
 
 	for range 100 {
-		scheduler.enqueue(1, func() { executions.Add(1) })
+		scheduler.enqueue(1, func(context.Context) { executions.Add(1) })
 	}
 	releaseOnce.Do(func() { close(release) })
-	scheduler.shutdown()
+	scheduler.Shutdown(context.Background())
 
 	if got := executions.Load(); got != 1 {
 		t.Fatalf("duplicate team executed %d times, want 1", got)
@@ -124,12 +125,12 @@ func TestLogoSchedulerQueuedWorkDoesNotCreateGoroutines(t *testing.T) {
 	var releaseOnce sync.Once
 	t.Cleanup(func() {
 		releaseOnce.Do(func() { close(release) })
-		scheduler.shutdown()
+		scheduler.Shutdown(context.Background())
 	})
 
 	started := make(chan struct{}, logoWorkerCount)
 	for teamID := int64(1); teamID <= logoWorkerCount; teamID++ {
-		scheduler.enqueue(teamID, func() {
+		scheduler.enqueue(teamID, func(context.Context) {
 			started <- struct{}{}
 			<-release
 		})
@@ -144,7 +145,7 @@ func TestLogoSchedulerQueuedWorkDoesNotCreateGoroutines(t *testing.T) {
 
 	before := runtime.NumGoroutine()
 	for teamID := int64(logoWorkerCount + 1); teamID <= 1000; teamID++ {
-		scheduler.enqueue(teamID, func() { <-release })
+		scheduler.enqueue(teamID, func(context.Context) { <-release })
 	}
 	runtime.Gosched()
 	after := runtime.NumGoroutine()
@@ -153,4 +154,78 @@ func TestLogoSchedulerQueuedWorkDoesNotCreateGoroutines(t *testing.T) {
 	}
 
 	releaseOnce.Do(func() { close(release) })
+}
+
+func TestLogoSchedulerShutdownFinishesActiveAndDiscardsQueuedWork(t *testing.T) {
+	scheduler := NewLogoScheduler()
+	release := make(chan struct{})
+	started := make(chan struct{}, logoWorkerCount)
+	completed := make(chan struct{}, logoWorkerCount)
+	for teamID := int64(1); teamID <= logoWorkerCount; teamID++ {
+		if !scheduler.enqueue(teamID, func(context.Context) {
+			started <- struct{}{}
+			<-release
+			completed <- struct{}{}
+		}) {
+			t.Fatalf("active team %d was rejected", teamID)
+		}
+	}
+	for range logoWorkerCount {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("workers did not start")
+		}
+	}
+
+	var queuedRan atomic.Bool
+	if !scheduler.enqueue(logoWorkerCount+1, func(context.Context) { queuedRan.Store(true) }) {
+		t.Fatal("queued work was rejected before shutdown")
+	}
+
+	scheduler.Stop()
+	if scheduler.enqueue(logoWorkerCount+2, func(context.Context) {}) {
+		t.Fatal("work was accepted after shutdown began")
+	}
+	close(release)
+	scheduler.Shutdown(context.Background())
+
+	for range logoWorkerCount {
+		select {
+		case <-completed:
+		default:
+			t.Fatal("active work did not finish")
+		}
+	}
+	if queuedRan.Load() {
+		t.Fatal("queued work ran after shutdown began")
+	}
+}
+
+func TestLogoSchedulerShutdownCancelsActiveWorkAtDeadline(t *testing.T) {
+	scheduler := NewLogoScheduler()
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	if !scheduler.enqueue(1, func(ctx context.Context) {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+	}) {
+		t.Fatal("active work was rejected")
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("work did not start")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	scheduler.Shutdown(ctx)
+
+	select {
+	case <-canceled:
+	default:
+		t.Fatal("shutdown returned before canceled work exited")
+	}
 }

--- a/internal/events/logo_store.go
+++ b/internal/events/logo_store.go
@@ -103,6 +103,10 @@ func TeamLogoAPIPath(teamID int64) string {
 	return fmt.Sprintf("/teams/logo/%d", teamID)
 }
 
+func TeamLogoSourceURL(teamID int64) string {
+	return fmt.Sprintf("https://img.sofascore.com/api/v1/team/%d/image", teamID)
+}
+
 func DownloadTeamLogo(teamID int64, sourceURL string) (string, error) {
 	return downloadTeamLogo(teamID, sourceURL, newImageHTTPClient())
 }

--- a/internal/events/logo_store.go
+++ b/internal/events/logo_store.go
@@ -108,10 +108,18 @@ func TeamLogoSourceURL(teamID int64) string {
 }
 
 func DownloadTeamLogo(teamID int64, sourceURL string) (string, error) {
-	return downloadTeamLogo(teamID, sourceURL, newImageHTTPClient())
+	return DownloadTeamLogoWithContext(context.Background(), teamID, sourceURL)
+}
+
+func DownloadTeamLogoWithContext(ctx context.Context, teamID int64, sourceURL string) (string, error) {
+	return downloadTeamLogoWithContext(ctx, teamID, sourceURL, newImageHTTPClient())
 }
 
 func downloadTeamLogo(teamID int64, sourceURL string, client *http.Client) (string, error) {
+	return downloadTeamLogoWithContext(context.Background(), teamID, sourceURL, client)
+}
+
+func downloadTeamLogoWithContext(ctx context.Context, teamID int64, sourceURL string, client *http.Client) (string, error) {
 	defer client.CloseIdleConnections()
 
 	localPath := TeamLogoLocalPath(teamID)
@@ -125,7 +133,7 @@ func downloadTeamLogo(teamID int64, sourceURL string, client *http.Client) (stri
 		return "", fmt.Errorf("could not create image storage directory: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, sourceURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("could not create image request: %w", err)
 	}

--- a/internal/events/logo_store_test.go
+++ b/internal/events/logo_store_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	utls "github.com/refraction-networking/utls"
 )
@@ -45,6 +47,39 @@ func TestDownloadTeamLogoClosesIdleConnections(t *testing.T) {
 	}
 	if !transport.closed {
 		t.Fatal("downloadTeamLogo did not close idle connections")
+	}
+}
+
+func TestDownloadTeamLogoWithContextCancelsRequest(t *testing.T) {
+	t.Setenv("IMAGE_STORAGE_PATH", t.TempDir())
+
+	requestStarted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := downloadTeamLogoWithContext(ctx, 123, server.URL, server.Client())
+		done <- err
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("image request did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("download succeeded after its context was canceled")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("download did not stop after context cancellation")
 	}
 }
 

--- a/internal/events/protobuf.go
+++ b/internal/events/protobuf.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"strings"
 	"time"
 
 	pb "github.com/jeriveromartinez/sofascore-scrapper/internal/gen/api"
@@ -15,8 +14,8 @@ func TeamToProto(t *Team) *pb.Team {
 	return &pb.Team{
 		Id:             uint32(t.ID),
 		TeamId:         t.TeamId,
-		LogoUrl:        t.LogoUrl,
 		Name:           t.Name,
+		LogoUrl:        "/api/app/v1" + TeamLogoAPIPath(t.TeamId),
 		PrimaryColor:   t.PrimaryColor,
 		SecondaryColor: t.SecondaryColor,
 		TextColor:      t.TextColor,
@@ -25,13 +24,7 @@ func TeamToProto(t *Team) *pb.Team {
 
 func EventToProto(e Event) *pb.SofaScoreEvent {
 	homeTeam := TeamToProto(e.HomeTeamModel)
-	if homeTeam != nil {
-		homeTeam.LogoUrl = logoURLForAPI(homeTeam.LogoUrl)
-	}
 	awayTeam := TeamToProto(e.AwayTeamModel)
-	if awayTeam != nil {
-		awayTeam.LogoUrl = logoURLForAPI(awayTeam.LogoUrl)
-	}
 
 	return &pb.SofaScoreEvent{
 		Id:                          uint32(e.ID),
@@ -52,14 +45,6 @@ func EventToProto(e Event) *pb.SofaScoreEvent {
 		TeamAway:                    awayTeam,
 		League:                      tournaments.TournamentPtrToProto(e.League),
 	}
-}
-
-func logoURLForAPI(rawURL string) string {
-	const apiPrefix = "/api/app/v1"
-	if strings.HasPrefix(rawURL, "/") && rawURL != apiPrefix && !strings.HasPrefix(rawURL, apiPrefix+"/") {
-		return apiPrefix + rawURL
-	}
-	return rawURL
 }
 
 func EventsToProto(events []Event) []*pb.SofaScoreEvent {

--- a/internal/events/protobuf_test.go
+++ b/internal/events/protobuf_test.go
@@ -11,7 +11,7 @@ func TestEventToProtoNormalizesLogoURLsWithoutMutatingModels(t *testing.T) {
 		{
 			name: "external SofaScore URL",
 			url:  "https://img.sofascore.com/api/v1/team/123/image",
-			want: "https://img.sofascore.com/api/v1/team/123/image",
+			want: "/api/app/v1/teams/logo/123",
 		},
 		{
 			name: "local relative URL",
@@ -26,7 +26,7 @@ func TestEventToProtoNormalizesLogoURLsWithoutMutatingModels(t *testing.T) {
 		{
 			name: "already prefixed root URL",
 			url:  "/api/app/v1",
-			want: "/api/app/v1",
+			want: "/api/app/v1/teams/logo/123",
 		},
 	}
 

--- a/internal/events/repository.go
+++ b/internal/events/repository.go
@@ -2,21 +2,16 @@ package events
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/jeriveromartinez/sofascore-scrapper/internal/tournaments"
-	"golang.org/x/sync/singleflight"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
-var (
-	downloadSem = make(chan struct{}, 10)
-	logoSF      singleflight.Group
-)
+var teamLogoScheduler = newLogoScheduler(logoWorkerCount)
 
 type Repository struct {
 	db           *gorm.DB
@@ -24,7 +19,7 @@ type Repository struct {
 }
 
 func NewRepository(db *gorm.DB) *Repository {
-	return &Repository{db: db, scheduleLogo: scheduleLogoSingleflight}
+	return &Repository{db: db, scheduleLogo: scheduleLogoDownload}
 }
 
 type pendingLogo struct {
@@ -168,18 +163,8 @@ func isProxiedLogoURL(url string) bool {
 	return strings.HasPrefix(url, "/teams/logo/") || strings.HasPrefix(url, "/api/app/v1/teams/logo/")
 }
 
-func enqueueTeamLogo(group *singleflight.Group, semaphore chan struct{}, teamID int64, work func()) {
-	key := fmt.Sprintf("logo-%d", teamID)
-	group.DoChan(key, func() (interface{}, error) {
-		semaphore <- struct{}{}
-		defer func() { <-semaphore }()
-		work()
-		return nil, nil
-	})
-}
-
-func scheduleLogoSingleflight(db *gorm.DB, teamID int64, sourceURL string) {
-	enqueueTeamLogo(&logoSF, downloadSem, teamID, func() {
+func scheduleLogoDownload(db *gorm.DB, teamID int64, sourceURL string) {
+	teamLogoScheduler.enqueue(teamID, func() {
 		downloadAndUpdateTeamLogo(db.Session(&gorm.Session{}), teamID, sourceURL)
 	})
 }

--- a/internal/events/repository.go
+++ b/internal/events/repository.go
@@ -19,11 +19,39 @@ var (
 )
 
 type Repository struct {
-	db *gorm.DB
+	db           *gorm.DB
+	scheduleLogo func(*gorm.DB, int64, string)
 }
 
 func NewRepository(db *gorm.DB) *Repository {
-	return &Repository{db: db}
+	return &Repository{db: db, scheduleLogo: scheduleLogoSingleflight}
+}
+
+type pendingLogo struct {
+	teamID    int64
+	sourceURL string
+}
+
+func prepareTeamLogo(team *Team) pendingLogo {
+	pending := pendingLogo{teamID: team.TeamId, sourceURL: team.LogoUrl}
+	team.LogoUrl = TeamLogoAPIPath(team.TeamId)
+	return pending
+}
+
+func (r *Repository) upsertTeam(ctx context.Context, team *Team) error {
+	pending := prepareTeamLogo(team)
+	if err := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "team_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"name", "logo_url", "primary_color", "secondary_color", "text_color",
+		}),
+	}).Create(team).Error; err != nil {
+		return err
+	}
+	if pending.sourceURL != "" && !isProxiedLogoURL(pending.sourceURL) {
+		r.scheduleLogo(r.db, pending.teamID, pending.sourceURL)
+	}
+	return nil
 }
 
 func (r *Repository) Upsert(ctx context.Context, events []Event, sport string) error {
@@ -34,16 +62,14 @@ func (r *Repository) Upsert(ctx context.Context, events []Event, sport string) e
 		event.Sport = sport
 
 		if event.HomeTeamModel != nil {
-			r.db.WithContext(nil).FirstOrCreate(event.HomeTeamModel, Team{TeamId: event.HomeTeamModel.TeamId})
-			if !isProxiedLogoURL(event.HomeTeamModel.LogoUrl) {
-				scheduleLogoDownload(r.db, event.HomeTeamModel.TeamId, event.HomeTeamModel.LogoUrl)
+			if err := r.upsertTeam(ctx, event.HomeTeamModel); err != nil {
+				return err
 			}
 		}
 
 		if event.AwayTeamModel != nil {
-			r.db.WithContext(nil).FirstOrCreate(event.AwayTeamModel, Team{TeamId: event.AwayTeamModel.TeamId})
-			if !isProxiedLogoURL(event.AwayTeamModel.LogoUrl) {
-				scheduleLogoDownload(r.db, event.AwayTeamModel.TeamId, event.AwayTeamModel.LogoUrl)
+			if err := r.upsertTeam(ctx, event.AwayTeamModel); err != nil {
+				return err
 			}
 		}
 
@@ -72,6 +98,14 @@ func (r *Repository) UpsertScrapeBatch(ctx context.Context, batch ScrapeBatch, b
 		batchSize = 500
 	}
 
+	pendingLogos := make([]pendingLogo, 0, len(batch.Teams))
+	for i := range batch.Teams {
+		pending := prepareTeamLogo(&batch.Teams[i])
+		if pending.sourceURL != "" && !isProxiedLogoURL(pending.sourceURL) {
+			pendingLogos = append(pendingLogos, pending)
+		}
+	}
+
 	now := time.Now().Unix()
 	for i := range batch.Events {
 		batch.Events[i].ScrapedAt = now
@@ -85,7 +119,7 @@ func (r *Repository) UpsertScrapeBatch(ctx context.Context, batch ScrapeBatch, b
 			if err := tx.Clauses(clause.OnConflict{
 				Columns: []clause.Column{{Name: "team_id"}},
 				DoUpdates: clause.AssignmentColumns([]string{
-					"name", "primary_color", "secondary_color", "text_color",
+					"name", "logo_url", "primary_color", "secondary_color", "text_color",
 				}),
 			}).CreateInBatches(batch.Teams, batchSize).Error; err != nil {
 				return err
@@ -123,10 +157,8 @@ func (r *Repository) UpsertScrapeBatch(ctx context.Context, batch ScrapeBatch, b
 		return err
 	}
 
-	for _, team := range batch.Teams {
-		if !isProxiedLogoURL(team.LogoUrl) {
-			scheduleLogoSingleflight(r.db, team.TeamId, team.LogoUrl)
-		}
+	for _, pending := range pendingLogos {
+		r.scheduleLogo(r.db, pending.teamID, pending.sourceURL)
 	}
 
 	return nil

--- a/internal/events/repository.go
+++ b/internal/events/repository.go
@@ -2,7 +2,10 @@ package events
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -20,6 +23,38 @@ type Repository struct {
 
 func NewRepository(db *gorm.DB) *Repository {
 	return &Repository{db: db, scheduleLogo: scheduleLogoDownload}
+}
+
+func (r *Repository) ReconcileTeamLogos(ctx context.Context) error {
+	var teams []Team
+	if err := r.db.WithContext(ctx).Find(&teams).Error; err != nil {
+		return fmt.Errorf("load teams for logo reconciliation: %w", err)
+	}
+
+	if err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, team := range teams {
+			localURL := TeamLogoAPIPath(team.TeamId)
+			if team.LogoUrl == localURL {
+				continue
+			}
+			if err := tx.Model(&Team{}).Where("team_id = ?", team.TeamId).Update("logo_url", localURL).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("normalize team logo URLs: %w", err)
+	}
+
+	for _, team := range teams {
+		if _, err := os.Stat(TeamLogoLocalPath(team.TeamId)); err == nil {
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("inspect logo for team %d: %w", team.TeamId, err)
+		}
+		r.scheduleLogo(r.db, team.TeamId, TeamLogoSourceURL(team.TeamId))
+	}
+	return nil
 }
 
 type pendingLogo struct {

--- a/internal/events/repository.go
+++ b/internal/events/repository.go
@@ -14,15 +14,24 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-var teamLogoScheduler = newLogoScheduler(logoWorkerCount)
-
 type Repository struct {
 	db           *gorm.DB
 	scheduleLogo func(*gorm.DB, int64, string)
 }
 
 func NewRepository(db *gorm.DB) *Repository {
-	return &Repository{db: db, scheduleLogo: scheduleLogoDownload}
+	return &Repository{
+		db:           db,
+		scheduleLogo: func(*gorm.DB, int64, string) {},
+	}
+}
+
+func NewRepositoryWithLogoScheduler(db *gorm.DB, scheduler TeamLogoScheduler) *Repository {
+	repository := NewRepository(db)
+	if scheduler != nil {
+		repository.scheduleLogo = scheduler.Schedule
+	}
+	return repository
 }
 
 func (r *Repository) ReconcileTeamLogos(ctx context.Context) error {
@@ -198,20 +207,17 @@ func isProxiedLogoURL(url string) bool {
 	return strings.HasPrefix(url, "/teams/logo/") || strings.HasPrefix(url, "/api/app/v1/teams/logo/")
 }
 
-func scheduleLogoDownload(db *gorm.DB, teamID int64, sourceURL string) {
-	teamLogoScheduler.enqueue(teamID, func() {
-		downloadAndUpdateTeamLogo(db.Session(&gorm.Session{}), teamID, sourceURL)
-	})
-}
-
-func downloadAndUpdateTeamLogo(db *gorm.DB, teamID int64, sourceURL string) {
-	if _, err := DownloadTeamLogo(teamID, sourceURL); err != nil {
+func downloadAndUpdateTeamLogo(ctx context.Context, db *gorm.DB, teamID int64, sourceURL string) {
+	if _, err := DownloadTeamLogoWithContext(ctx, teamID, sourceURL); err != nil {
 		log.Printf("events: failed to download logo for team %d: %v", teamID, err)
+		return
+	}
+	if ctx.Err() != nil {
 		return
 	}
 
 	apiPath := TeamLogoAPIPath(teamID)
-	if err := db.Model(&Team{}).Where("team_id = ?", teamID).Update("logo_url", apiPath).Error; err != nil {
+	if err := db.WithContext(ctx).Model(&Team{}).Where("team_id = ?", teamID).Update("logo_url", apiPath).Error; err != nil {
 		log.Printf("events: failed to update logo URL for team %d: %v", teamID, err)
 	}
 }

--- a/internal/events/repository.go
+++ b/internal/events/repository.go
@@ -168,27 +168,19 @@ func isProxiedLogoURL(url string) bool {
 	return strings.HasPrefix(url, "/teams/logo/") || strings.HasPrefix(url, "/api/app/v1/teams/logo/")
 }
 
-func scheduleLogoDownload(db *gorm.DB, teamID int64, sourceURL string) {
-	select {
-	case downloadSem <- struct{}{}:
-		go func() {
-			defer func() { <-downloadSem }()
-			downloadAndUpdateTeamLogo(db.Session(&gorm.Session{}), teamID, sourceURL)
-		}()
-	default:
-	}
+func enqueueTeamLogo(group *singleflight.Group, semaphore chan struct{}, teamID int64, work func()) {
+	key := fmt.Sprintf("logo-%d", teamID)
+	group.DoChan(key, func() (interface{}, error) {
+		semaphore <- struct{}{}
+		defer func() { <-semaphore }()
+		work()
+		return nil, nil
+	})
 }
 
 func scheduleLogoSingleflight(db *gorm.DB, teamID int64, sourceURL string) {
-	key := fmt.Sprintf("logo-%d", teamID)
-	logoSF.DoChan(key, func() (interface{}, error) {
-		select {
-		case downloadSem <- struct{}{}:
-			defer func() { <-downloadSem }()
-			downloadAndUpdateTeamLogo(db.Session(&gorm.Session{}), teamID, sourceURL)
-		default:
-		}
-		return nil, nil
+	enqueueTeamLogo(&logoSF, downloadSem, teamID, func() {
+		downloadAndUpdateTeamLogo(db.Session(&gorm.Session{}), teamID, sourceURL)
 	})
 }
 

--- a/internal/events/repository_integration_test.go
+++ b/internal/events/repository_integration_test.go
@@ -223,3 +223,32 @@ func TestUpsert_ErrorReturned(t *testing.T) {
 		t.Errorf("upsert with conflict should not error: %v", err)
 	}
 }
+
+func TestUpsertPersistsLocalLogoURLs(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+	repo.scheduleLogo = func(_ *gorm.DB, _ int64, _ string) {}
+
+	const remoteURL = "https://img.sofascore.com/api/v1/team/10/image"
+	home := &Team{TeamId: 10, Name: "Home", LogoUrl: remoteURL}
+	away := &Team{TeamId: 20, Name: "Away", LogoUrl: remoteURL}
+	event := Event{
+		SofaScoreEventId: 1,
+		HomeTeamId:       10,
+		AwayTeamId:       20,
+		HomeTeamModel:    home,
+		AwayTeamModel:    away,
+		StatusType:       "notstarted",
+	}
+	if err := repo.Upsert(context.Background(), []Event{event}, "football"); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	var teams []Team
+	if err := db.Order("team_id").Find(&teams).Error; err != nil {
+		t.Fatalf("load teams: %v", err)
+	}
+	if len(teams) != 2 || teams[0].LogoUrl != "/teams/logo/10" || teams[1].LogoUrl != "/teams/logo/20" {
+		t.Fatalf("persisted teams = %#v", teams)
+	}
+}

--- a/internal/scraper/convert.go
+++ b/internal/scraper/convert.go
@@ -1,7 +1,6 @@
 package scraper
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
@@ -17,7 +16,7 @@ func ToTeam(source TeamApi) events.Team {
 		PrimaryColor:   source.Colors.Primary,
 		SecondaryColor: source.Colors.Secondary,
 		TextColor:      source.Colors.Text,
-		LogoUrl:        "https://img.sofascore.com/api/v1/team/" + fmt.Sprint(source.ID) + "/image",
+		LogoUrl:        events.TeamLogoSourceURL(source.ID),
 	}
 }
 

--- a/internal/testing/convert_test.go
+++ b/internal/testing/convert_test.go
@@ -256,8 +256,8 @@ func TestEventsToProto(t *testing.T) {
 	if len(result) != 2 {
 		t.Fatalf("expected 2, got %d", len(result))
 	}
-	if result[0].TeamHome.LogoUrl != "/api/app/v1/team/10/image" {
-		t.Errorf("expected LogoUrl='/api/app/v1/team/10/image', got %s", result[0].TeamHome.LogoUrl)
+	if result[0].TeamHome.LogoUrl != "/api/app/v1/teams/logo/10" {
+		t.Errorf("expected LogoUrl='/api/app/v1/teams/logo/10', got %s", result[0].TeamHome.LogoUrl)
 	}
 }
 


### PR DESCRIPTION
## Summary
- persist and serialize team logos exclusively through the local API route
- replace lossy download scheduling with an app-owned, coalesced 10-worker queue
- reconcile historical logo URLs and retry missing files before HTTP startup
- shut down logo workers before closing SQL resources

## Testing
- `go test ./... -count=1`
- `go test -tags=integration -count=1 -p 1 -timeout 300s ./internal/events`
- `go vet ./...`
- `git diff --check origin/main..HEAD`

## Notes
- `go test -race` could not run in the current Windows environment because CGO is disabled and GCC is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team logos are now stored and served through consistent local API paths.
  * Missing or updated logos are downloaded automatically in the background.
  * Logo downloads support cancellation and graceful application shutdown.

* **Bug Fixes**
  * Prevented duplicate logo downloads and ensured cached logos are reused when available.
  * Standardized team logo links across events and scraped data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->