### PR TITLE
test(events): reframe protobuf_test around TeamToProto's canonical-logo contract

### DIFF
--- a/internal/events/protobuf_test.go
+++ b/internal/events/protobuf_test.go
@@ -2,50 +2,84 @@ package events
 
 import "testing"
 
-func TestEventToProtoNormalizesLogoURLsWithoutMutatingModels(t *testing.T) {
+func TestTeamToProtoAlwaysEmitsCanonicalLocalLogoURL(t *testing.T) {
 	tests := []struct {
-		name string
-		url  string
-		want string
+		name         string
+		storedLogo   string
+		wantLogoURL  string
 	}{
 		{
-			name: "external SofaScore URL",
-			url:  "https://img.sofascore.com/api/v1/team/123/image",
-			want: "/api/app/v1/teams/logo/123",
+			name:        "empty stored URL still resolves to canonical local path",
+			storedLogo:  "",
+			wantLogoURL: "/api/app/v1/teams/logo/123",
 		},
 		{
-			name: "local relative URL",
-			url:  "/teams/logo/123",
-			want: "/api/app/v1/teams/logo/123",
+			name:        "external SofaScore URL is overridden by canonical local path",
+			storedLogo:  "https://img.sofascore.com/api/v1/team/123/image",
+			wantLogoURL: "/api/app/v1/teams/logo/123",
 		},
 		{
-			name: "already prefixed local URL",
-			url:  "/api/app/v1/teams/logo/123",
-			want: "/api/app/v1/teams/logo/123",
+			name:        "protocol-relative URL is overridden by canonical local path",
+			storedLogo:  "//cdn.example/x",
+			wantLogoURL: "/api/app/v1/teams/logo/123",
 		},
 		{
-			name: "already prefixed root URL",
-			url:  "/api/app/v1",
-			want: "/api/app/v1/teams/logo/123",
+			name:        "local relative URL is overridden by canonical local path",
+			storedLogo:  "/teams/logo/123",
+			wantLogoURL: "/api/app/v1/teams/logo/123",
+		},
+		{
+			name:        "already-prefixed local URL stays canonical (no double prefix)",
+			storedLogo:  "/api/app/v1/teams/logo/123",
+			wantLogoURL: "/api/app/v1/teams/logo/123",
+		},
+		{
+			name:        "api root URL is overridden by canonical local path",
+			storedLogo:  "/api/app/v1",
+			wantLogoURL: "/api/app/v1/teams/logo/123",
+		},
+		{
+			name:        "api prefix with trailing slash is overridden by canonical local path",
+			storedLogo:  "/api/app/v1/",
+			wantLogoURL: "/api/app/v1/teams/logo/123",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			team := &Team{TeamId: 123, LogoUrl: tt.url}
-			event := Event{HomeTeamModel: team}
+			team := &Team{TeamId: 123, LogoUrl: tt.storedLogo}
 
-			first := EventToProto(event)
-			second := EventToProto(event)
+			first := TeamToProto(team)
+			second := TeamToProto(team)
 
-			if first.TeamHome.LogoUrl != tt.want {
-				t.Fatalf("first logo URL = %q, want %q", first.TeamHome.LogoUrl, tt.want)
+			if first.LogoUrl != tt.wantLogoURL {
+				t.Fatalf("first.LogoUrl = %q, want %q", first.LogoUrl, tt.wantLogoURL)
 			}
-			if second.TeamHome.LogoUrl != tt.want {
-				t.Fatalf("second logo URL = %q, want %q", second.TeamHome.LogoUrl, tt.want)
+			if second.LogoUrl != tt.wantLogoURL {
+				t.Fatalf("second.LogoUrl = %q, want %q", second.LogoUrl, tt.wantLogoURL)
 			}
-			if team.LogoUrl != tt.url {
-				t.Fatalf("EventToProto mutated model URL from %q to %q", tt.url, team.LogoUrl)
+			if team.LogoUrl != tt.storedLogo {
+				t.Fatalf("TeamToProto mutated source model: LogoUrl = %q, want %q", team.LogoUrl, tt.storedLogo)
+			}
+		})
+	}
+}
+
+func TestTeamToProtoUsesTeamIDForCanonicalPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		teamID int64
+		want   string
+	}{
+		{name: "normal id", teamID: 42, want: "/api/app/v1/teams/logo/42"},
+		{name: "zero id", teamID: 0, want: "/api/app/v1/teams/logo/0"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TeamToProto(&Team{TeamId: tt.teamID})
+			if got.LogoUrl != tt.want {
+				t.Fatalf("LogoUrl = %q, want %q", got.LogoUrl, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What

A tests-only change.

Issue #30 (`Harden logoURLForAPI against empty/duplicate-prefixed inputs`) targeted a helper that **no longer exists**. PR #25 (`fix(events): serve team logos locally`, commit `2aa9c02`) deleted `logoURLForAPI` and rewrote `TeamToProto` so that `LogoUrl` is **always** built from the team's own ID, ignoring whatever is stored in `Team.LogoUrl`:

```go
LogoUrl: "/api/app/v1" + TeamLogoAPIPath(t.TeamId),
```

That refactor silently retired every edge case the issue described (empty `""`, `//cdn.example/x`, `/api/app/v1` root, trailing-slash duplicates). None of them can happen any more.

The existing test (`TestEventToProtoNormalizesLogoURLsWithoutMutatingModels`) was passing only by accident — all four sub-cases asserted the same `want: "/api/app/v1/teams/logo/123"` regardless of input, so it stopped exercising the helper it was named after without anyone noticing.

## What this PR does

Two test functions that pin the actual current contract:

| Test | Sub-cases | Coverage |
|------|-----------|----------|
| `TestTeamToProtoAlwaysEmitsCanonicalLocalLogoURL` | 7 | Empty stored URL, external HTTPS, `//cdn.example/x`, local relative, already-prefixed local, `/api/app/v1` root, `/api/app/v1/` trailing-slash — all must collapse to `/api/app/v1/teams/logo/123`. Plus the original mutation check (the source `Team.LogoUrl` is never edited in place). |
| `TestTeamToProtoUsesTeamIDForCanonicalPath` | 2 | Normal id (`42` → `/api/app/v1/teams/logo/42`), zero id (`0` → `/api/app/v1/teams/logo/0`). Pins the URL shape so future refactors cannot silently change it. |

`TestEventToProtoHandlesMissingTeams` is kept as-is.

## Why

- Closes #30 — the bug it described was eliminated by #25; this PR records the new contract so the bug cannot regress.
- The old test was technically green but conceptually dead (it asserted the same output for every input, including inputs that the deleted helper used to handle differently).

## How it was tested

- `go test -count=1 -timeout 120s ./...` → all packages `ok` (including the 10 new sub-tests).
- `go vet ./...` → clean.
- No production code changed.

## Files

- `internal/events/protobuf_test.go` — replaced `TestEventToProtoNormalizesLogoURLsWithoutMutatingModels` with the two tests above.

## Out of scope

The protocol-relative-URL behavior the original audit worried about (Flutter appending `dashboardDomain` to `//cdn.example/x`) is moot now because the backend always returns the canonical local path; any URL Flutter receives is one the backend produced. If a future refactor brings back a `LogoUrl` value that varies, that risk returns and these tests will need to be revisited.

## Closes

#30