### PR TITLE
chore(proto): add Makefile wrapping protoc + cross-repo Flutter check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,20 +36,11 @@ jobs:
       - name: Install protoc-gen-go
         run: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
-      - name: Regenerate proto
-        run: |
-          protoc \
-            --go_out=. \
-            --go_opt=module=github.com/jeriveromartinez/sofascore-scrapper \
-            proto/api.proto
+      - name: Install make
+        run: sudo apt-get update && sudo apt-get install -y make
 
-      - name: Check proto is up to date
-        run: |
-          if ! git diff --exit-code internal/gen/; then
-            echo "Generated protobuf code is out of date. Run 'protoc --go_out=...' and commit."
-            git diff internal/gen/
-            exit 1
-          fi
+      - name: Regenerate proto and verify
+        run: make proto-check
 
   gofmt:
     name: gofmt check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+GO_MODULE := github.com/jeriveromartinez/sofascore-scrapper
+PROTO_FILE := proto/api.proto
+GENERATED_DIR := internal/gen
+FLUTTER_PROTO_URL := https://raw.githubusercontent.com/jeriveromartinez/flutter-apptv/main/proto/api.proto
+
+.PHONY: proto proto-check proto-verify-flutter help
+
+help:
+	@echo "Available targets:"
+	@echo "  make proto                  Regenerate Go bindings from $(PROTO_FILE)"
+	@echo "  make proto-check           Regenerate and fail if internal/gen/ has uncommitted changes"
+	@echo "  make proto-verify-flutter   Fail if flutter-apptv's proto/api.proto drifts from this one"
+
+# Regenerate Go bindings from proto/api.proto.
+# Output lands in $(GENERATED_DIR) because that matches the `option go_package`
+# in $(PROTO_FILE).
+proto:
+	protoc \
+		--go_out=. \
+		--go_opt=module=$(GO_MODULE) \
+		$(PROTO_FILE)
+
+# Regenerate and fail if the working tree has uncommitted changes inside
+# $(GENERATED_DIR). Used by the CI `proto-diff` job to catch stale bindings.
+proto-check: proto
+	@if ! git diff --exit-code $(GENERATED_DIR) > /dev/null 2>&1; then \
+		echo "Generated protobuf code is out of date. Run 'make proto' and commit."; \
+		git diff $(GENERATED_DIR); \
+		exit 1; \
+	fi
+	@echo "Generated protobuf code is up to date."
+
+# Verify the Flutter client's proto/api.proto is a verbatim copy of this repo's.
+# The contract is documented in docs/integration-audit-roadmap.md: the Go repo
+# is the source of truth and flutter-apptv must mirror proto/api.proto.
+proto-verify-flutter:
+	@curl -fsSL $(FLUTTER_PROTO_URL) -o /tmp/flutter-api.proto
+	@if ! diff -q $(PROTO_FILE) /tmp/flutter-api.proto > /dev/null 2>&1; then \
+		echo "Flutter proto is out of sync with the Go source of truth."; \
+		echo "Run 'cp $(PROTO_FILE) ../flutter-apptv/proto/api.proto' and regenerate the Dart bindings."; \
+		diff $(PROTO_FILE) /tmp/flutter-api.proto | head -80; \
+		exit 1; \
+	fi
+	@echo "Flutter proto is in sync."

--- a/README.md
+++ b/README.md
@@ -149,21 +149,24 @@ cd web && npm run test:unit
 cd web && npm run test:e2e
 cd web && npm run build
 
-# Generate protobuf (Go)
-PATH="$PATH:/D/.go/bin" protoc \
-  --proto_path="E:/Projects/IPTV/sofascore-scrapper" \
-  --go_out="E:/Projects/IPTV/sofascore-scrapper" \
-  --go_opt=module=github.com/jeriveromartinez/sofascore-scrapper \
-  "E:/Projects/IPTV/sofascore-scrapper/proto/api.proto"
+# Regenerate Go protobuf bindings (this repo is the source of truth for proto/api.proto)
+make proto
 
-# Generate protobuf (Vue/TypeScript)
-protoc \
-  --proto_path=E:/Projects/IPTV/sofascore-scrapper \
-  --plugin=protoc-gen-ts_proto=E:/Projects/IPTV/sofascore-scrapper/web/node_modules/.bin/protoc-gen-ts_proto.cmd \
-  --ts_proto_out=E:/Projects/IPTV/sofascore-scrapper/web/src \
-  --ts_proto_opt=esModuleInterop=true,outputClientImpl=false \
-  E:/Projects/IPTV/sofascore-scrapper/proto/api.proto
+# Verify generated bindings match proto/api.proto
+make proto-check
+
+# Verify flutter-apptv/proto/api.proto mirrors this repo's (cross-repo contract)
+make proto-verify-flutter
+
+# Generate protobuf (Vue/TypeScript) — see web/package.json scripts
+cd web && npm run proto
 ```
+
+> **Proto sync contract.** `proto/api.proto` in this repo is the single source of
+> truth. The Flutter client (`flutter-apptv/proto/api.proto`) and the Vue/TypeScript
+> web client (`web/src/...`) must mirror it. CI enforces the Go bindings via
+> `make proto-check`; the cross-repo check against Flutter is `make proto-verify-flutter`
+> (run it locally before opening a PR that touches `proto/api.proto`).
 
 ## API Endpoints
 

--- a/internal/testing/makefile_test.go
+++ b/internal/testing/makefile_test.go
@@ -1,0 +1,85 @@
+package characterization
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runMakeDry(t *testing.T, target string) string {
+	t.Helper()
+	bin, err := lookupMake()
+	if err != nil {
+		t.Skipf("`make` not available on PATH: %v", err)
+	}
+	cmd := exec.Command(bin, "-f", makefilePath(t), "-n", target)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s -f %s -n %s failed: %v\noutput:\n%s", bin, makefilePath(t), target, err, string(out))
+	}
+	return string(out)
+}
+
+func makefilePath(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs("../../Makefile")
+	if err != nil {
+		t.Fatalf("resolve Makefile path: %v", err)
+	}
+	return abs
+}
+
+func lookupMake() (string, error) {
+	for _, candidate := range []string{"make", "mingw32-make", "gmake"} {
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path, nil
+		}
+	}
+	return "", exec.ErrNotFound
+}
+
+func TestMakefileProtoTargetUsesProtoc(t *testing.T) {
+	out := runMakeDry(t, "proto")
+
+	if !strings.Contains(out, "protoc") {
+		t.Errorf("make proto dry-run does not invoke protoc; got:\n%s", out)
+	}
+	if !strings.Contains(out, "--go_out=") {
+		t.Errorf("make proto dry-run missing --go_out flag; got:\n%s", out)
+	}
+	if !strings.Contains(out, "proto/api.proto") {
+		t.Errorf("make proto dry-run missing proto/api.proto input; got:\n%s", out)
+	}
+	if !strings.Contains(out, "github.com/jeriveromartinez/sofascore-scrapper") {
+		t.Errorf("make proto dry-run missing go module path; got:\n%s", out)
+	}
+}
+
+func TestMakefileProtoCheckVerifiesGitDiff(t *testing.T) {
+	out := runMakeDry(t, "proto-check")
+
+	if !strings.Contains(out, "protoc") {
+		t.Errorf("make proto-check dry-run does not invoke protoc; got:\n%s", out)
+	}
+	if !strings.Contains(out, "git diff") {
+		t.Errorf("make proto-check dry-run does not invoke git diff; got:\n%s", out)
+	}
+	if !strings.Contains(out, "internal/gen") {
+		t.Errorf("make proto-check dry-run does not inspect internal/gen; got:\n%s", out)
+	}
+}
+
+func TestMakefileProtoVerifyFlutterFetchesFlutterProto(t *testing.T) {
+	out := runMakeDry(t, "proto-verify-flutter")
+
+	if !strings.Contains(out, "curl") {
+		t.Errorf("make proto-verify-flutter dry-run does not invoke curl; got:\n%s", out)
+	}
+	if !strings.Contains(out, "flutter-apptv") {
+		t.Errorf("make proto-verify-flutter dry-run does not reference flutter-apptv; got:\n%s", out)
+	}
+	if !strings.Contains(out, "proto/api.proto") {
+		t.Errorf("make proto-verify-flutter dry-run missing proto/api.proto path; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## What

The protoc invocation for the Go bindings lived only in the README's "Commands" section as a Windows-specific shell snippet, and the CI reimplemented the same command inline. The cross-repo contract (flutter-apptv/proto/api.proto mirrors this one) had no scriptable check anywhere.

A small Makefile + three dry-run tests + CI + README changes.

## Makefile targets

| Target | What it does |
|--------|--------------|
| `make proto` | Regenerate `internal/gen/` from `proto/api.proto`. |
| `make proto-check` | Regenerate and fail if `internal/gen/` has any uncommitted changes. **This is what the CI `proto-diff` job now runs.** |
| `make proto-verify-flutter` | Curl flutter-apptv's main branch proto, diff against this one. Optional; documents the cross-repo contract. |

## Files

- `Makefile` (new) — the three targets above. Wraps the protoc command the CI was running inline.
- `.github/workflows/ci.yml` — replaced the inline protoc + git-diff steps in `proto-diff` with `make proto-check`. Kept the protoc and protoc-gen-go install steps verbatim.
- `README.md` — replaced the Windows-specific protoc snippet in "Commands" with the three `make` targets. Added a short note that this repo's `proto/api.proto` is the source of truth and that Flutter mirrors it via `make proto-verify-flutter`.
- `internal/testing/makefile_test.go` (new, package `characterization`) — three tests that run `make -n <target>` and assert the dry-run output mentions the right commands and files.

## How it was tested

```
go test -count=1 -timeout 120s ./...
```

All packages `ok`; the three new tests pass. They use `make -n` so they don't actually invoke protoc — they just verify the Makefile wires the right things together. Skips gracefully if no `make` binary is on PATH.

`go vet ./...` clean.

```
gofmt -l .
```

The repo already has a long-standing list of files ungo-fmt'd (everything under `web/pkg/mod/` plus a number of `internal/*.go`). The new files (`Makefile`, `internal/testing/makefile_test.go`) are gofmt-clean. Not in scope.

## Notes (out of scope)

- The Vue/TypeScript web client regenerates its bindings via `web/package.json` scripts, not Make. README now says so.
- The existing `proto-diff` CI job was already in place; this PR consolidates it to use the Makefile but does not change its semantics.
- The cross-repo check is opt-in (developers run it locally). CI does not run it because it requires internet access and depends on flutter-apptv's main branch; making it mandatory would require extra CI configuration that wasn't asked for.

## Closes

#28
