### PR TITLE
fix(admin-events): hint UTC in date filter error and document the contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,14 @@ Every other `/api/web/v1/*` route requires **Admin** — user, device, event, pl
 (including resumable uploads), tournament, domain, and global-config management, plus
 reporting (`GET /stats/top-events`). See `internal/app/routes.go` for the authoritative list.
 
+#### Query parameters worth knowing
+
+- `GET /api/web/v1/events?date=YYYY-MM-DD` — `date` is parsed as **midnight-to-midnight
+  UTC** (`time.Parse("2006-01-02", date)`). An operator outside UTC sees events for the
+  previous/next day at the boundary; convert to UTC before passing the value. Other
+  query parameters (`sport`, `page`, `limit`) are local to that endpoint; see the
+  handler for details.
+
 ## Authorization & Roles
 
 The management API uses JWT bearer authentication (`AuthMiddleware`) plus role-based access control:

--- a/internal/events/admin_handler.go
+++ b/internal/events/admin_handler.go
@@ -122,7 +122,7 @@ func (h *AdminHandler) handleGetEvents(c *gin.Context) {
 	if date != "" {
 		t, err := time.Parse("2006-01-02", date)
 		if err != nil {
-			server.RespondError(c, http.StatusBadRequest, "date must use YYYY-MM-DD format")
+			server.RespondError(c, http.StatusBadRequest, "date must use YYYY-MM-DD format (UTC)")
 			return
 		}
 		start := t.UnixMilli()

--- a/internal/events/admin_handler_test.go
+++ b/internal/events/admin_handler_test.go
@@ -1,8 +1,10 @@
 package events
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,5 +92,23 @@ func TestAdminEventsRejectsInvalidDate(t *testing.T) {
 
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("status: want %d, got %d", http.StatusBadRequest, recorder.Code)
+	}
+}
+
+func TestAdminEventsInvalidDateMentionsUTC(t *testing.T) {
+	db := setupAdminHandlerTestDB(t)
+
+	recorder, _ := getAdminEvents(t, NewAdminHandler(db), "/events?date=not-a-date")
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status: want %d, got %d", http.StatusBadRequest, recorder.Code)
+	}
+
+	body := map[string]string{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if !strings.Contains(body["error"], "UTC") {
+		t.Errorf("error message should mention UTC so callers know the day boundary is interpreted in UTC; got %q", body["error"])
 	}
 }


### PR DESCRIPTION
## What

`handleGetEvents` parses `?date=YYYY-MM-DD` with `time.Parse` (UTC) and then queries `[start, start+24h)` in milliseconds. The README never mentioned the timezone, and the 400 error said only `"date must use YYYY-MM-DD format"` — an operator outside UTC who passes the local day would silently get the wrong slice.

Two small changes, no behavior change to the successful path:

- **`internal/events/admin_handler.go`** — append `" (UTC)"` to the 400 error body.
- **`README.md`** — under Management API, add a "Query parameters worth knowing" subsection that documents the `date` parameter is UTC and points at the source for the other params.

## Why

Closes #31.

## How it was tested

`internal/events/admin_handler_test.go` (extended):

| Test | State |
|------|-------|
| `TestAdminEventsInvalidDateMentionsUTC` (new) | ✅ — asserts that a malformed `?date` produces an error body whose `error` field contains `"UTC"`. |

The existing `TestAdminEventsRejectsInvalidDate` still passes (the status-code contract is unchanged).

`go test -count=1 -timeout 120s ./...` → all packages `ok`.
`go vet ./...` → clean.

## Files

- `internal/events/admin_handler.go` — one-line change to the error message.
- `internal/events/admin_handler_test.go` — added one test plus `encoding/json` and `strings` imports.
- `README.md` — added a small subsection under Management API documenting the UTC contract.

## Closes

#31